### PR TITLE
Stage 11.0: concurrency adapters for compare sections

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -235,7 +235,9 @@ func addProjectInteractive(cli client.ClientInterface, cmd *cobra.Command) error
 		return fmt.Errorf("failed to create project: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Project created (ID: %d)", project.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Project created (ID: %d)", project.ID)
+	}
 	return output.OutputResult(cmd, project, "result")
 }
 
@@ -269,7 +271,9 @@ func addSuiteInteractive(cli client.ClientInterface, cmd *cobra.Command, project
 		return fmt.Errorf("failed to create suite: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Suite created (ID: %d)", suite.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Suite created (ID: %d)", suite.ID)
+	}
 	return output.OutputResult(cmd, suite, "result")
 }
 
@@ -307,7 +311,9 @@ func addCaseInteractive(cli client.ClientInterface, cmd *cobra.Command, sectionI
 		return fmt.Errorf("failed to create case: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Case created (ID: %d)", caseResp.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Case created (ID: %d)", caseResp.ID)
+	}
 	return output.OutputResult(cmd, caseResp, "result")
 }
 
@@ -345,7 +351,9 @@ func addRunInteractive(cli client.ClientInterface, cmd *cobra.Command, projectID
 		return fmt.Errorf("failed to create run: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Run created (ID: %d)", run.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Run created (ID: %d)", run.ID)
+	}
 	return output.OutputResult(cmd, run, "result")
 }
 
@@ -874,8 +882,10 @@ func addAttachmentToCase(cli client.ClientInterface, cmd *cobra.Command, caseID 
 		return fmt.Errorf("failed to add attachment to case: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
-	ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
+		ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	}
 	return output.OutputResult(cmd, resp, "result")
 }
 
@@ -897,8 +907,10 @@ func addAttachmentToPlan(cli client.ClientInterface, cmd *cobra.Command, planID 
 		return fmt.Errorf("failed to add attachment to plan: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
-	ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
+		ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	}
 	return output.OutputResult(cmd, resp, "result")
 }
 
@@ -920,8 +932,10 @@ func addAttachmentToPlanEntry(cli client.ClientInterface, cmd *cobra.Command, pl
 		return fmt.Errorf("failed to add attachment to plan entry: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
-	ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
+		ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	}
 	return output.OutputResult(cmd, resp, "result")
 }
 
@@ -943,8 +957,10 @@ func addAttachmentToResult(cli client.ClientInterface, cmd *cobra.Command, resul
 		return fmt.Errorf("failed to add attachment to result: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
-	ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
+		ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	}
 	return output.OutputResult(cmd, resp, "result")
 }
 
@@ -966,7 +982,9 @@ func addAttachmentToRun(cli client.ClientInterface, cmd *cobra.Command, runID in
 		return fmt.Errorf("failed to add attachment to run: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
-	ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Attachment added (ID: %d)", resp.AttachmentID)
+		ui.Infof(os.Stdout, "URL: %s", resp.URL)
+	}
 	return output.OutputResult(cmd, resp, "result")
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -71,7 +71,7 @@ func initGlobalFlags() {
 	rootCmd.PersistentFlags().MarkHidden("debug")
 
 	// Quiet mode (тихий режим для CI/CD)
-	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Тихий режим (только результат, без прогресса)")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Подавить служебный вывод (прогресс, статистику, сообщения о сохранении)")
 
 	// Формат вывода (глобальный)
 	rootCmd.PersistentFlags().StringP("format", "f", "table", "Формат вывода: table, json, csv, md, html")

--- a/cmd/compare/all.go
+++ b/cmd/compare/all.go
@@ -414,7 +414,7 @@ Examples:
 
 			// Sections
 			announce("sections")
-			if sectionsResult, err := compareSectionsInternalWithSuites(ctx, cli, pid1, pid2, quiet, preloadedSuites); err == nil {
+			if sectionsResult, err := compareSectionsInternalWithSuites(ctx, cmd, cli, pid1, pid2, quiet, preloadedSuites); err == nil {
 				result.Sections = sectionsResult
 			} else {
 				recordErr("sections", err)
@@ -564,9 +564,10 @@ Examples:
 					if err := saveAllResult(result, format, savePath); err != nil {
 						return err
 					}
-					// Print on new line after progress bar
-					fmt.Println()
-					ui.Infof(os.Stdout, "Result saved to %s", savePath)
+					if !quiet {
+						fmt.Println()
+						ui.Infof(os.Stdout, "Result saved to %s", savePath)
+					}
 				case "table":
 					return saveAllSummaryToFile(cmd, result, project1Name, pid1, project2Name, pid2, errors, savePath, time.Since(startTime))
 				default:
@@ -790,9 +791,11 @@ func saveAllSummaryToFile(cmd *cobra.Command, result *allResult, project1Name st
 		return fmt.Errorf("file write error: %w", err)
 	}
 
-	// Print on new line after progress bar
-	fmt.Println()
-	ui.Infof(os.Stdout, "Result saved to %s", filePath)
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	if !quiet {
+		fmt.Println()
+		ui.Infof(os.Stdout, "Result saved to %s", filePath)
+	}
 	return nil
 }
 

--- a/cmd/compare/cases.go
+++ b/cmd/compare/cases.go
@@ -320,7 +320,9 @@ func compareCasesInternal(ctx context.Context, cmd *cobra.Command, cli client.Cl
 	result := analyzeCases(cases1, cases2, pid1, pid2, field)
 	elapsed := time.Since(start)
 
-	ui.Successf(os.Stderr, "Analysis completed (%s)", elapsed.Round(time.Millisecond))
+	if !quiet {
+		ui.Successf(os.Stderr, "Analysis completed (%s)", elapsed.Round(time.Millisecond))
+	}
 	debug.DebugPrint("[Compare] Analysis complete: P%d=%d unique, P%d=%d unique, common=%d",
 		pid1, len(result.OnlyInFirst), pid2, len(result.OnlyInSecond), len(result.Common))
 
@@ -472,7 +474,7 @@ func fetchCasesForProject(ctx context.Context, cli client.ClientInterface, proje
 	return allCases, nil, pds, nil
 }
 
-func collectCompareCasesFlagOverrides(cmd *cobra.Command) map[string]any {
+func collectCompareHeavyFlagOverrides(cmd *cobra.Command) map[string]any {
 	overrides := map[string]any{}
 
 	if flag := cmd.Flags().Lookup("rate-limit"); flag != nil && flag.Changed {
@@ -509,6 +511,10 @@ func collectCompareCasesFlagOverrides(cmd *cobra.Command) map[string]any {
 	}
 
 	return overrides
+}
+
+func collectCompareCasesFlagOverrides(cmd *cobra.Command) map[string]any {
+	return collectCompareHeavyFlagOverrides(cmd)
 }
 
 func saveFailedPagesReport(failedPages []concurrency.FailedPage, requestedPath string) (string, error) {

--- a/cmd/compare/config_profile.go
+++ b/cmd/compare/config_profile.go
@@ -9,15 +9,19 @@ import (
 )
 
 type compareCasesRuntimeConfig struct {
+	compareHeavyRuntimeConfig
+	RetryAttempts        int
+	RetryWorkers         int
+	RetryDelay           time.Duration
+	AutoRetryFailedPages bool
+}
+
+type compareHeavyRuntimeConfig struct {
 	RateLimit            int
 	ParallelSuites       int
 	ParallelPages        int
 	PageRetries          int
 	Timeout              time.Duration
-	RetryAttempts        int
-	RetryWorkers         int
-	RetryDelay           time.Duration
-	AutoRetryFailedPages bool
 }
 
 func ensureCompareConfigDefaults() {
@@ -42,6 +46,60 @@ func resolveCompareCasesRuntimeConfig(
 	cmdFlags map[string]any,
 	baseURL string,
 ) (compareCasesRuntimeConfig, error) {
+	heavyCfg, err := resolveCompareHeavyRuntimeConfig(cmdFlags, baseURL)
+	if err != nil {
+		return compareCasesRuntimeConfig{}, err
+	}
+
+	ensureCompareConfigDefaults()
+
+	retryAttempts := viper.GetInt("compare.cases.retry.attempts")
+	if retryAttempts <= 0 {
+		retryAttempts = 5
+	}
+	if isFlagProvided(cmdFlags, "retry_attempts") {
+		retryAttempts = cmdFlags["retry_attempts"].(int)
+	}
+
+	retryWorkers := viper.GetInt("compare.cases.retry.workers")
+	if retryWorkers <= 0 {
+		retryWorkers = 12
+	}
+	if isFlagProvided(cmdFlags, "retry_workers") {
+		retryWorkers = cmdFlags["retry_workers"].(int)
+	}
+
+	retryDelay := 500 * time.Millisecond
+	retryDelayText := strings.TrimSpace(viper.GetString("compare.cases.retry.delay"))
+	if retryDelayText != "" {
+		parsed, err := time.ParseDuration(retryDelayText)
+		if err != nil {
+			return compareCasesRuntimeConfig{}, fmt.Errorf("invalid compare.cases.retry.delay in config: %w", err)
+		}
+		retryDelay = parsed
+	}
+	if isFlagProvided(cmdFlags, "retry_delay") {
+		retryDelay = cmdFlags["retry_delay"].(time.Duration)
+	}
+
+	autoRetry := viper.GetBool("compare.cases.auto_retry_failed_pages")
+	if !viper.IsSet("compare.cases.auto_retry_failed_pages") {
+		autoRetry = true
+	}
+
+	return compareCasesRuntimeConfig{
+		compareHeavyRuntimeConfig: heavyCfg,
+		RetryAttempts:             retryAttempts,
+		RetryWorkers:              retryWorkers,
+		RetryDelay:                retryDelay,
+		AutoRetryFailedPages:      autoRetry,
+	}, nil
+}
+
+func resolveCompareHeavyRuntimeConfig(
+	cmdFlags map[string]any,
+	baseURL string,
+) (compareHeavyRuntimeConfig, error) {
 	ensureCompareConfigDefaults()
 
 	deployment := strings.ToLower(strings.TrimSpace(viper.GetString("compare.deployment")))
@@ -96,7 +154,7 @@ func resolveCompareCasesRuntimeConfig(
 	if timeoutText != "" {
 		parsed, err := time.ParseDuration(timeoutText)
 		if err != nil {
-			return compareCasesRuntimeConfig{}, fmt.Errorf("invalid compare.cases.timeout in config: %w", err)
+			return compareHeavyRuntimeConfig{}, fmt.Errorf("invalid compare.cases.timeout in config: %w", err)
 		}
 		timeout = parsed
 	}
@@ -104,50 +162,12 @@ func resolveCompareCasesRuntimeConfig(
 		timeout = cmdFlags["timeout"].(time.Duration)
 	}
 
-	retryAttempts := viper.GetInt("compare.cases.retry.attempts")
-	if retryAttempts <= 0 {
-		retryAttempts = 5
-	}
-	if isFlagProvided(cmdFlags, "retry_attempts") {
-		retryAttempts = cmdFlags["retry_attempts"].(int)
-	}
-
-	retryWorkers := viper.GetInt("compare.cases.retry.workers")
-	if retryWorkers <= 0 {
-		retryWorkers = 12
-	}
-	if isFlagProvided(cmdFlags, "retry_workers") {
-		retryWorkers = cmdFlags["retry_workers"].(int)
-	}
-
-	retryDelay := 500 * time.Millisecond
-	retryDelayText := strings.TrimSpace(viper.GetString("compare.cases.retry.delay"))
-	if retryDelayText != "" {
-		parsed, err := time.ParseDuration(retryDelayText)
-		if err != nil {
-			return compareCasesRuntimeConfig{}, fmt.Errorf("invalid compare.cases.retry.delay in config: %w", err)
-		}
-		retryDelay = parsed
-	}
-	if isFlagProvided(cmdFlags, "retry_delay") {
-		retryDelay = cmdFlags["retry_delay"].(time.Duration)
-	}
-
-	autoRetry := viper.GetBool("compare.cases.auto_retry_failed_pages")
-	if !viper.IsSet("compare.cases.auto_retry_failed_pages") {
-		autoRetry = true
-	}
-
-	return compareCasesRuntimeConfig{
-		RateLimit:            rateLimit,
-		ParallelSuites:       parallelSuites,
-		ParallelPages:        parallelPages,
-		PageRetries:          pageRetries,
-		Timeout:              timeout,
-		RetryAttempts:        retryAttempts,
-		RetryWorkers:         retryWorkers,
-		RetryDelay:           retryDelay,
-		AutoRetryFailedPages: autoRetry,
+	return compareHeavyRuntimeConfig{
+		RateLimit:      rateLimit,
+		ParallelSuites: parallelSuites,
+		ParallelPages:  parallelPages,
+		PageRetries:    pageRetries,
+		Timeout:        timeout,
 	}, nil
 }
 

--- a/cmd/compare/fetchers_test.go
+++ b/cmd/compare/fetchers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Korrnals/gotr/internal/concurrency"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -217,7 +218,7 @@ func TestCompareSectionsInternal_Success(t *testing.T) {
 		},
 	}
 
-	result, err := compareSectionsInternal(context.Background(), mock, 1, 2, false)
+	result, err := compareSectionsInternal(context.Background(), nil, mock, 1, 2, false)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -231,10 +232,57 @@ func TestCompareSectionsInternal_SuitesError(t *testing.T) {
 		},
 	}
 
-	result, err := compareSectionsInternal(context.Background(), mock, 1, 2, false)
+	result, err := compareSectionsInternal(context.Background(), nil, mock, 1, 2, false)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestCompareSectionsInternal_UsesHeavyRuntimeConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("compare.rate_limit", 120)
+	viper.Set("compare.cases.parallel_suites", 4)
+	viper.Set("compare.cases.parallel_pages", 5)
+	viper.Set("compare.cases.page_retries", 6)
+	viper.Set("compare.cases.timeout", "3m")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("parallel-suites", 10, "")
+	cmd.Flags().Int("parallel-pages", 6, "")
+	cmd.Flags().Int("page-retries", 5, "")
+	cmd.Flags().Int("rate-limit", -1, "")
+	cmd.Flags().Duration("timeout", 30*time.Minute, "")
+	_ = cmd.Flags().Set("parallel-suites", "8")
+	_ = cmd.Flags().Set("timeout", "7m")
+
+	preloaded := map[int64]data.GetSuitesResponse{
+		1: {{ID: 101, Name: "Suite A"}},
+		2: {{ID: 201, Name: "Suite B"}},
+	}
+
+	captured := make([]*concurrency.ControllerConfig, 0, 2)
+	mock := &client.MockClient{
+		GetSectionsParallelCtxFunc: func(ctx context.Context, projectID int64, suiteIDs []int64, config *concurrency.ControllerConfig) (data.GetSectionsResponse, error) {
+			captured = append(captured, config)
+			if projectID == 1 {
+				return data.GetSectionsResponse{{ID: 1, SuiteID: 101, Name: "Alpha"}}, nil
+			}
+			return data.GetSectionsResponse{{ID: 2, SuiteID: 201, Name: "Beta"}}, nil
+		},
+	}
+
+	result, err := compareSectionsInternalWithSuites(context.Background(), cmd, mock, 1, 2, true, preloaded)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, captured, 2)
+
+	assert.Equal(t, 8, captured[0].MaxConcurrentSuites)
+	assert.Equal(t, 5, captured[0].MaxConcurrentPages)
+	assert.Equal(t, 6, captured[0].MaxRetries)
+	assert.Equal(t, 120, captured[0].RequestsPerMinute)
+	assert.Equal(t, 7*time.Minute, captured[0].Timeout)
 }
 
 // ==================== Тесты для compareSimpleInternal (plans) ====================

--- a/cmd/compare/quiet_test.go
+++ b/cmd/compare/quiet_test.go
@@ -1,0 +1,211 @@
+package compare
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/Korrnals/gotr/internal/client"
+	"github.com/Korrnals/gotr/internal/models/data"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStandardIO(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	require.NoError(t, err)
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	var copyWG sync.WaitGroup
+	copyWG.Add(2)
+
+	go func() {
+		defer copyWG.Done()
+		_, _ = io.Copy(&stdoutBuf, stdoutReader)
+	}()
+	go func() {
+		defer copyWG.Done()
+		_, _ = io.Copy(&stderrBuf, stderrReader)
+	}()
+
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	require.NoError(t, stdoutWriter.Close())
+	require.NoError(t, stderrWriter.Close())
+	copyWG.Wait()
+
+	return stdoutBuf.String(), stderrBuf.String()
+}
+
+func quietPlansMock() *client.MockClient {
+	return &client.MockClient{
+		GetProjectFunc: func(ctx context.Context, projectID int64) (*data.GetProjectResponse, error) {
+			return &data.GetProjectResponse{ID: projectID, Name: "Test Project"}, nil
+		},
+		GetPlansFunc: func(ctx context.Context, projectID int64) (data.GetPlansResponse, error) {
+			if projectID == 1 {
+				return data.GetPlansResponse{{ID: 10, Name: "Plan A"}}, nil
+			}
+			return data.GetPlansResponse{{ID: 20, Name: "Plan B"}}, nil
+		},
+	}
+}
+
+func quietAllMock() *client.MockClient {
+	return &client.MockClient{
+		GetProjectFunc: func(ctx context.Context, projectID int64) (*data.GetProjectResponse, error) {
+			return &data.GetProjectResponse{ID: projectID, Name: "Test Project"}, nil
+		},
+		GetSuitesFunc: func(ctx context.Context, projectID int64) (data.GetSuitesResponse, error) {
+			return []data.Suite{}, nil
+		},
+		GetCasesFunc: func(ctx context.Context, projectID, suiteID, sectionID int64) (data.GetCasesResponse, error) {
+			return []data.Case{}, nil
+		},
+		GetSectionsFunc: func(ctx context.Context, projectID, suiteID int64) (data.GetSectionsResponse, error) {
+			return []data.Section{}, nil
+		},
+		GetSharedStepsFunc: func(ctx context.Context, projectID int64) (data.GetSharedStepsResponse, error) {
+			return []data.SharedStep{}, nil
+		},
+		GetRunsFunc: func(ctx context.Context, projectID int64) (data.GetRunsResponse, error) {
+			return []data.Run{}, nil
+		},
+		GetPlansFunc: func(ctx context.Context, projectID int64) (data.GetPlansResponse, error) {
+			return []data.Plan{}, nil
+		},
+		GetMilestonesFunc: func(ctx context.Context, projectID int64) ([]data.Milestone, error) {
+			return []data.Milestone{}, nil
+		},
+		GetDatasetsFunc: func(ctx context.Context, projectID int64) (data.GetDatasetsResponse, error) {
+			return []data.Dataset{}, nil
+		},
+		GetGroupsFunc: func(ctx context.Context, projectID int64) (data.GetGroupsResponse, error) {
+			return []data.Group{}, nil
+		},
+		GetLabelsFunc: func(ctx context.Context, projectID int64) (data.GetLabelsResponse, error) {
+			return []data.Label{}, nil
+		},
+		GetTemplatesFunc: func(ctx context.Context, projectID int64) (data.GetTemplatesResponse, error) {
+			return []data.Template{}, nil
+		},
+		GetConfigsFunc: func(ctx context.Context, projectID int64) (data.GetConfigsResponse, error) {
+			return []data.ConfigGroup{}, nil
+		},
+	}
+}
+
+func TestPlansCmd_Quiet_JSON_PrintsOnlyResult(t *testing.T) {
+	SetGetClientForTests(func(cmd *cobra.Command) client.ClientInterface {
+		return quietPlansMock()
+	})
+
+	cmd := newSimpleCompareCmd("plans", "plans", "test", "test", fetchPlanItems)
+	addPersistentFlagsForTests(cmd)
+	cmd.SetArgs([]string{"--pid1=1", "--pid2=2", "--format=json", "--quiet"})
+
+	var cmdStdout bytes.Buffer
+	var cmdStderr bytes.Buffer
+	cmd.SetOut(&cmdStdout)
+	cmd.SetErr(&cmdStderr)
+
+	stdout, stderr := captureStandardIO(t, func() {
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+	assert.Empty(t, cmdStderr.String())
+	assert.Contains(t, cmdStdout.String(), "\"resource\": \"plans\"")
+	assert.Contains(t, cmdStdout.String(), "\"status\": \"complete\"")
+	assert.NotContains(t, cmdStdout.String(), "STATS:")
+	assert.NotContains(t, cmdStdout.String(), "Analysis completed")
+	assert.NotContains(t, cmdStdout.String(), "Result saved to")
+}
+
+func TestPlansCmd_Quiet_SaveTo_SuppressesSuccessOutput(t *testing.T) {
+	SetGetClientForTests(func(cmd *cobra.Command) client.ClientInterface {
+		return quietPlansMock()
+	})
+
+	tmpDir := t.TempDir()
+	savePath := filepath.Join(tmpDir, "plans.json")
+
+	cmd := newSimpleCompareCmd("plans", "plans", "test", "test", fetchPlanItems)
+	addPersistentFlagsForTests(cmd)
+	cmd.SetArgs([]string{"--pid1=1", "--pid2=2", "--format=json", "--quiet", "--save-to=" + savePath})
+
+	var cmdStdout bytes.Buffer
+	var cmdStderr bytes.Buffer
+	cmd.SetOut(&cmdStdout)
+	cmd.SetErr(&cmdStderr)
+
+	stdout, stderr := captureStandardIO(t, func() {
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+	assert.Empty(t, cmdStdout.String())
+	assert.Empty(t, cmdStderr.String())
+
+	content, err := os.ReadFile(savePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "\"resource\": \"plans\"")
+}
+
+func TestAllCmd_Quiet_SaveTo_SuppressesSuccessOutput(t *testing.T) {
+	SetGetClientForTests(func(cmd *cobra.Command) client.ClientInterface {
+		return quietAllMock()
+	})
+
+	tmpDir := t.TempDir()
+	savePath := filepath.Join(tmpDir, "all.json")
+
+	cmd := newAllCmd()
+	addPersistentFlagsForTests(cmd)
+	cmd.SetArgs([]string{"--pid1=1", "--pid2=2", "--format=json", "--quiet", "--save-to=" + savePath})
+
+	var cmdStdout bytes.Buffer
+	var cmdStderr bytes.Buffer
+	cmd.SetOut(&cmdStdout)
+	cmd.SetErr(&cmdStderr)
+
+	stdout, stderr := captureStandardIO(t, func() {
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+	assert.Empty(t, cmdStdout.String())
+	assert.Empty(t, cmdStderr.String())
+
+	content, err := os.ReadFile(savePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "\"meta\"")
+	assert.Contains(t, string(content), "\"execution_status\": \"complete\"")
+}

--- a/cmd/compare/sections.go
+++ b/cmd/compare/sections.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/ui"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // newSectionsCmd creates the 'compare sections' subcommand.
@@ -55,7 +56,7 @@ Examples:
 
 			// Compare sections
 			quiet, _ := cmd.Flags().GetBool("quiet")
-			result, err := compareSectionsInternal(ctx, cli, pid1, pid2, quiet)
+			result, err := compareSectionsInternal(ctx, cmd, cli, pid1, pid2, quiet)
 			if err != nil {
 				return err
 			}
@@ -86,12 +87,12 @@ Examples:
 // sectionsCmd is the exported command.
 var sectionsCmd = newSectionsCmd()
 
-// compareSectionsInternal compares sections between two projects using FetchParallel.
-func compareSectionsInternal(ctx context.Context, cli client.ClientInterface, pid1, pid2 int64, quiet bool) (*CompareResult, error) {
-	return compareSectionsInternalWithSuites(ctx, cli, pid1, pid2, quiet, nil)
+// compareSectionsInternal compares sections between two projects using client adapter path.
+func compareSectionsInternal(ctx context.Context, cmd *cobra.Command, cli client.ClientInterface, pid1, pid2 int64, quiet bool) (*CompareResult, error) {
+	return compareSectionsInternalWithSuites(ctx, cmd, cli, pid1, pid2, quiet, nil)
 }
 
-func compareSectionsInternalWithSuites(ctx context.Context, cli client.ClientInterface, pid1, pid2 int64, quiet bool, preloaded map[int64]data.GetSuitesResponse) (*CompareResult, error) {
+func compareSectionsInternalWithSuites(ctx context.Context, cmd *cobra.Command, cli client.ClientInterface, pid1, pid2 int64, quiet bool, preloaded map[int64]data.GetSuitesResponse) (*CompareResult, error) {
 	operation := ui.NewOperation(ui.StatusConfig{
 		Title:  "Loading sections",
 		Writer: os.Stderr,
@@ -113,6 +114,16 @@ func compareSectionsInternalWithSuites(ctx context.Context, cli client.ClientInt
 	suites1 := suitesMap[pid1]
 	suites2 := suitesMap[pid2]
 
+	var runtimeConfig compareHeavyRuntimeConfig
+	if cmd != nil {
+		runtimeConfig, err = resolveCompareHeavyRuntimeConfig(collectCompareHeavyFlagOverrides(cmd), viper.GetString("base_url"))
+	} else {
+		runtimeConfig, err = resolveCompareHeavyRuntimeConfig(nil, viper.GetString("base_url"))
+	}
+	if err != nil {
+		return nil, err
+	}
+
 	task1 := operation.AddTask(fmt.Sprintf("P%d (%d suites)", pid1, len(suites1)), taskTotal(len(suites1)))
 	task2 := operation.AddTask(fmt.Sprintf("P%d (%d suites)", pid2, len(suites2)), taskTotal(len(suites2)))
 
@@ -123,13 +134,13 @@ func compareSectionsInternalWithSuites(ctx context.Context, cli client.ClientInt
 	done2 := make(chan struct{})
 
 	go func() {
-		items1, err1 = fetchSectionsForProject(ctx, cli, pid1, suites1, task1)
+		items1, err1 = fetchSectionsForProject(ctx, cli, pid1, suites1, task1, runtimeConfig)
 		task1.Finish()
 		close(done1)
 	}()
 
 	go func() {
-		items2, err2 = fetchSectionsForProject(ctx, cli, pid2, suites2, task2)
+		items2, err2 = fetchSectionsForProject(ctx, cli, pid2, suites2, task2, runtimeConfig)
 		task2.Finish()
 		close(done2)
 	}()
@@ -165,119 +176,24 @@ func compareSectionsInternalWithSuites(ctx context.Context, cli client.ClientInt
 	return compareItemInfos("sections", pid1, pid2, items1, items2), nil
 }
 
-// fetchSectionItems fetches all sections for a project, parallelizing across suites
-// using FetchParallelBySuite.
-func fetchSectionItems(ctx context.Context, cli client.ClientInterface, projectID int64) ([]ItemInfo, error) {
-	// Get all suites for the project
-	suites, err := cli.GetSuites(ctx, projectID)
-	if err != nil {
-		return nil, err
-	}
-
-	// If no suites, try without suite filter
-	if len(suites) == 0 {
-		sections, err := cli.GetSections(ctx, projectID, 0)
-		if err != nil {
-			return nil, err
-		}
-		items := make([]ItemInfo, 0, len(sections))
-		for _, s := range sections {
-			items = append(items, ItemInfo{ID: s.ID, Name: s.Name})
-		}
-		return items, nil
-	}
-
-	// Build suite ID list and name map
-	suiteIDs := make([]int64, len(suites))
-	suiteNames := make(map[int64]string)
-	for i, s := range suites {
-		suiteIDs[i] = s.ID
-		suiteNames[s.ID] = s.Name
-	}
-
-	// Fetch sections from all suites in parallel
-	allSections, err := concurrency.FetchParallelBySuite(ctx, suiteIDs,
-		func(suiteID int64) ([]ItemInfo, error) {
-			sections, sErr := cli.GetSections(ctx, projectID, suiteID)
-			if sErr != nil {
-				return nil, sErr
-			}
-			items := make([]ItemInfo, 0, len(sections))
-			suiteName := suiteNames[suiteID]
-			for _, s := range sections {
-				name := s.Name
-				if suiteName != "" {
-					name = fmt.Sprintf("%s / %s", suiteName, s.Name)
-				}
-				items = append(items, ItemInfo{ID: s.ID, Name: name})
-			}
-			return items, nil
-		},
-		concurrency.WithContinueOnError(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Deduplicate by ID
-	seen := make(map[int64]bool)
-	result := make([]ItemInfo, 0, len(allSections))
-	for _, item := range allSections {
-		if !seen[item.ID] {
-			seen[item.ID] = true
-			result = append(result, item)
-		}
-	}
-
-	return result, nil
-}
-
-func fetchSectionsForProject(ctx context.Context, cli client.ClientInterface, projectID int64, suites data.GetSuitesResponse, task ui.TaskHandle) ([]ItemInfo, error) {
-	if len(suites) == 0 {
-		sections, err := cli.GetSections(ctx, projectID, 0)
-		if err != nil {
-			return nil, err
-		}
-
-		items := make([]ItemInfo, 0, len(sections))
-		for _, section := range sections {
-			items = append(items, ItemInfo{ID: section.ID, Name: section.Name})
-		}
-
-		task.Increment()
-		task.Add(len(items))
-		return items, nil
-	}
-
-	suiteIDs := make([]int64, len(suites))
+func fetchSectionsForProject(ctx context.Context, cli client.ClientInterface, projectID int64, suites data.GetSuitesResponse, task ui.TaskHandle, runtimeConfig compareHeavyRuntimeConfig) ([]ItemInfo, error) {
+	suiteIDs := make([]int64, 0, len(suites))
 	suiteNames := make(map[int64]string, len(suites))
-	for i, suite := range suites {
-		suiteIDs[i] = suite.ID
+	for _, suite := range suites {
+		suiteIDs = append(suiteIDs, suite.ID)
 		suiteNames[suite.ID] = suite.Name
 	}
 
-	allSections, err := concurrency.FetchParallelBySuite(ctx, suiteIDs,
-		func(suiteID int64) ([]ItemInfo, error) {
-			sections, fetchErr := cli.GetSections(ctx, projectID, suiteID)
-			if fetchErr != nil {
-				return nil, fetchErr
-			}
+	controllerConfig := &concurrency.ControllerConfig{
+		MaxConcurrentSuites: runtimeConfig.ParallelSuites,
+		MaxConcurrentPages:  runtimeConfig.ParallelPages,
+		RequestsPerMinute:   runtimeConfig.RateLimit,
+		MaxRetries:          runtimeConfig.PageRetries,
+		Timeout:             runtimeConfig.Timeout,
+		Reporter:            task,
+	}
 
-			items := make([]ItemInfo, 0, len(sections))
-			suiteName := suiteNames[suiteID]
-			for _, section := range sections {
-				name := section.Name
-				if suiteName != "" {
-					name = fmt.Sprintf("%s / %s", suiteName, section.Name)
-				}
-				items = append(items, ItemInfo{ID: section.ID, Name: name})
-			}
-			return items, nil
-		},
-		concurrency.WithContinueOnError(),
-		concurrency.WithReporter(task),
-		concurrency.WithMaxConcurrency(10),
-	)
+	sections, err := cli.GetSectionsParallelCtx(ctx, projectID, suiteIDs, controllerConfig)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -285,14 +201,25 @@ func fetchSectionsForProject(ctx context.Context, cli client.ClientInterface, pr
 		return nil, err
 	}
 
-	seen := make(map[int64]bool, len(allSections))
-	result := make([]ItemInfo, 0, len(allSections))
-	for _, item := range allSections {
-		if seen[item.ID] {
+	if len(suites) == 0 {
+		task.Increment()
+		task.Add(len(sections))
+	}
+
+	seen := make(map[int64]bool, len(sections))
+	result := make([]ItemInfo, 0, len(sections))
+	for _, section := range sections {
+		if seen[section.ID] {
 			continue
 		}
-		seen[item.ID] = true
-		result = append(result, item)
+		seen[section.ID] = true
+
+		name := section.Name
+		if suiteName := suiteNames[section.SuiteID]; suiteName != "" {
+			name = fmt.Sprintf("%s / %s", suiteName, section.Name)
+		}
+
+		result = append(result, ItemInfo{ID: section.ID, Name: name})
 	}
 
 	return result, nil

--- a/cmd/compare/test_helper.go
+++ b/cmd/compare/test_helper.go
@@ -12,6 +12,7 @@ func addPersistentFlagsForTests(cmd *cobra.Command) {
 	cmd.Flags().StringP("pid1", "1", "", "ID первого проекта")
 	cmd.Flags().StringP("pid2", "2", "", "ID второго проекта")
 	cmd.Flags().StringP("format", "f", "table", "Формат вывода")
+	cmd.Flags().BoolP("quiet", "q", false, "Подавить служебный вывод")
 	cmd.Flags().Bool("save", false, "Сохранить результат")
 	cmd.Flags().String("save-to", "", "Сохранить в указанный файл")
 	cmd.Flags().Int("rate-limit", -1, "")

--- a/cmd/compare/types.go
+++ b/cmd/compare/types.go
@@ -129,7 +129,10 @@ func PrintCompareResult(cmd *cobra.Command, result CompareResult, project1Name, 
 			if err := saveToFileWithPath(result, format, savePath); err != nil {
 				return err
 			}
-			// Message is printed by saveToFile
+			if q, _ := cmd.Flags().GetBool("quiet"); !q {
+				fmt.Println()
+				ui.Infof(os.Stdout, "Result saved to %s", savePath)
+			}
 		case "table":
 			// Save table as text
 			return saveTableToFile(cmd, result, project1Name, project2Name, savePath)
@@ -495,19 +498,15 @@ func saveCSV(result CompareResult, savePath string) error {
 		}
 	}
 
-	// Print on new line after progress bar
-	fmt.Println()
-	ui.Infof(os.Stdout, "Result saved to %s", savePath)
 	return nil
 }
 
-// saveToFile saves data to a file
+// saveToFile saves data to a file.
+// Callers are responsible for printing confirmation (respecting quiet flag).
 func saveToFile(data []byte, savePath string) error {
 	if err := os.WriteFile(savePath, data, 0644); err != nil {
 		return fmt.Errorf("file write error: %w", err)
 	}
-	fmt.Println()
-	ui.Infof(os.Stdout, "Result saved to %s", savePath)
 	return nil
 }
 
@@ -570,8 +569,10 @@ func saveTableToFile(cmd *cobra.Command, result CompareResult, project1Name, pro
 		return fmt.Errorf("file write error: %w", err)
 	}
 
-	fmt.Println()
-	ui.Infof(os.Stdout, "Result saved to %s", filePath)
+	if q, _ := cmd.Flags().GetBool("quiet"); !q {
+		fmt.Println()
+		ui.Infof(os.Stdout, "Result saved to %s", filePath)
+	}
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,9 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		debug.DebugPrint("{rootCmd} - Running command: %s", cmd.Use)
 		debug.DebugPrint("{rootCmd} - Arguments: %v", args)
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		ui.SetMessageQuiet(quiet)
+
 		// Настройка Viper - поддержка env, флагов, конфигов
 		viper.AutomaticEnv() // автоматически подтягивать переменные из окружения
 

--- a/cmd/sync/sync_cases.go
+++ b/cmd/sync/sync_cases.go
@@ -54,6 +54,7 @@ var casesCmd = &cobra.Command{
 		dstSuite, _ := cmd.Flags().GetInt64("dst-suite")
 		compareField, _ := cmd.Flags().GetString("compare-field")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		quiet := isQuiet(cmd)
 		outputFile, _ := cmd.Flags().GetString("output")
 		mappingFile, _ := cmd.Flags().GetString("mapping-file")
 
@@ -110,13 +111,13 @@ var casesCmd = &cobra.Command{
 		}
 		defer m.Close()
 
-		op := newSyncOperation("Sync cases")
+		op := newSyncOperation("Sync cases", quiet)
 		defer op.Finish()
 
 		// Если указан mapping-файл — загрузим в m.mapping
 		if mappingFile != "" {
 			op.Phase("Loading mapping")
-			_, err := runSyncStatus(ctx, "Loading mapping...", func(context.Context) (struct{}, error) {
+			_, err := runSyncStatus(ctx, "Loading mapping...", quiet, func(context.Context) (struct{}, error) {
 				return struct{}{}, m.LoadMappingFromFile(mappingFile)
 			})
 			if err != nil {
@@ -128,7 +129,7 @@ var casesCmd = &cobra.Command{
 		}
 
 		op.Phase("Loading cases")
-		loaded, err := runSyncStatus(ctx, "Loading cases...", func(ctx context.Context) (struct {
+		loaded, err := runSyncStatus(ctx, "Loading cases...", quiet, func(ctx context.Context) (struct {
 			Source data.GetCasesResponse
 			Target data.GetCasesResponse
 		}, error) {
@@ -167,13 +168,15 @@ var casesCmd = &cobra.Command{
 			}
 		}
 
-		fmt.Printf("\nAnalysis result:\n")
-		fmt.Printf("  Matches: %d\n", len(matches))
-		fmt.Printf("  New: %d\n", len(filtered))
+		if !quiet {
+			fmt.Printf("\nAnalysis result:\n")
+			fmt.Printf("  Matches: %d\n", len(matches))
+			fmt.Printf("  New: %d\n", len(filtered))
+		}
 
 		if dryRun {
 			ui.Info(os.Stdout, "Dry-run: import NOT performed (safe).")
-			saveLog(logFile, matches, filtered, nil, m.Mapping())
+			saveLog(logFile, matches, filtered, nil, m.Mapping(), quiet)
 			return nil
 		}
 
@@ -185,12 +188,12 @@ var casesCmd = &cobra.Command{
 		confirm = strings.ToLower(strings.TrimSpace(confirm))
 		if confirm != "y" && confirm != "yes" {
 			ui.Cancelled(os.Stdout)
-			saveLog(logFile, matches, filtered, nil, m.Mapping())
+			saveLog(logFile, matches, filtered, nil, m.Mapping(), quiet)
 			return nil
 		}
 
 		op.Phase("Importing cases")
-		imported, err := runSyncStatus(ctx, fmt.Sprintf("Importing %d cases...", len(filtered)), func(ctx context.Context) (struct {
+		imported, err := runSyncStatus(ctx, fmt.Sprintf("Importing %d cases...", len(filtered)), quiet, func(ctx context.Context) (struct {
 			IDs    []int64
 			Errors []string
 		}, error) {
@@ -222,13 +225,13 @@ var casesCmd = &cobra.Command{
 		}
 
 		// Сохраняем лог и mapping
-		saveLog(logFile, matches, filtered, importErrors, m.Mapping())
+		saveLog(logFile, matches, filtered, importErrors, m.Mapping(), quiet)
 
 		return nil
 	},
 }
 
-func saveLog(file string, matches, filtered data.GetCasesResponse, errors []string, mapping map[int64]int64) {
+func saveLog(file string, matches, filtered data.GetCasesResponse, errors []string, mapping map[int64]int64, quiet bool) {
 	result := map[string]interface{}{
 		"timestamp": time.Now().Format(time.RFC3339),
 		"matches":   len(matches),
@@ -238,5 +241,7 @@ func saveLog(file string, matches, filtered data.GetCasesResponse, errors []stri
 	}
 	jsonData, _ := json.MarshalIndent(result, "", "  ")
 	os.WriteFile(file, jsonData, 0644)
-	ui.Infof(os.Stdout, "Log saved: %s", file)
+	if !quiet {
+		ui.Infof(os.Stdout, "Log saved: %s", file)
+	}
 }

--- a/cmd/sync/sync_full.go
+++ b/cmd/sync/sync_full.go
@@ -38,6 +38,7 @@ var fullCmd = &cobra.Command{
 		dstSuite, _ := cmd.Flags().GetInt64("dst-suite")
 		compareField, _ := cmd.Flags().GetString("compare-field")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		quiet := isQuiet(cmd)
 		autoApprove, _ := cmd.Flags().GetBool("approve")
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
 
@@ -85,12 +86,12 @@ var fullCmd = &cobra.Command{
 		}
 		defer m.Close()
 
-		op := newSyncOperation("Full migration")
+		op := newSyncOperation("Full migration", quiet)
 		defer op.Finish()
 
 		// Шаг 1) Миграция shared steps (Fetch → Filter → Import)
 		op.Phase("Step 1/2: shared steps")
-		_, err = runSyncStatus(ctx, "Migrating shared steps...", func(ctx context.Context) (struct{}, error) {
+		_, err = runSyncStatus(ctx, "Migrating shared steps...", quiet, func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, m.MigrateSharedSteps(ctx, dryRun || !autoApprove)
 		})
 		if err != nil { // если dry-run — без импорта
@@ -104,7 +105,7 @@ var fullCmd = &cobra.Command{
 
 		// Шаг 2) Миграция cases (Fetch → Filter → Import)
 		op.Phase("Step 2/2: cases")
-		_, err = runSyncStatus(ctx, "Migrating cases...", func(ctx context.Context) (struct{}, error) {
+		_, err = runSyncStatus(ctx, "Migrating cases...", quiet, func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, m.MigrateCases(ctx, dryRun)
 		})
 		if err != nil {

--- a/cmd/sync/sync_helpers.go
+++ b/cmd/sync/sync_helpers.go
@@ -6,21 +6,32 @@ import (
 
 	"github.com/Korrnals/gotr/internal/service/migration"
 	"github.com/Korrnals/gotr/internal/ui"
+	"github.com/spf13/cobra"
 )
 
 // newMigration — seam для тестов; по умолчанию указывает на migration.NewMigration
 var newMigration = migration.NewMigration
 
-func newSyncOperation(title string) ui.Operation {
+func isQuiet(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	return quiet
+}
+
+func newSyncOperation(title string, quiet bool) ui.Operation {
 	return ui.NewOperation(ui.StatusConfig{
 		Title:  title,
 		Writer: os.Stderr,
+		Quiet:  quiet,
 	})
 }
 
-func runSyncStatus[T any](ctx context.Context, title string, fn func(context.Context) (T, error)) (T, error) {
+func runSyncStatus[T any](ctx context.Context, title string, quiet bool, fn func(context.Context) (T, error)) (T, error) {
 	return ui.RunWithStatus(ctx, ui.StatusConfig{
 		Title:  title,
 		Writer: os.Stderr,
+		Quiet:  quiet,
 	}, fn)
 }

--- a/cmd/sync/sync_sections.go
+++ b/cmd/sync/sync_sections.go
@@ -41,6 +41,7 @@ var sectionsCmd = &cobra.Command{
 		dstSuite, _ := cmd.Flags().GetInt64("dst-suite")
 		compareField, _ := cmd.Flags().GetString("compare-field")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		quiet := isQuiet(cmd)
 		autoApprove, _ := cmd.Flags().GetBool("approve")
 
 		var err error
@@ -88,12 +89,12 @@ var sectionsCmd = &cobra.Command{
 		}
 		defer m.Close()
 
-		op := newSyncOperation("Sync sections")
+		op := newSyncOperation("Sync sections", quiet)
 		defer op.Finish()
 
 		// Шаг 1) Получение sections из source и target
 		op.Phase("Loading sections")
-		loaded, err := runSyncStatus(ctx, "Loading sections...", func(ctx context.Context) (struct {
+		loaded, err := runSyncStatus(ctx, "Loading sections...", quiet, func(ctx context.Context) (struct {
 			Source data.GetSectionsResponse
 			Target data.GetSectionsResponse
 		}, error) {
@@ -148,7 +149,7 @@ var sectionsCmd = &cobra.Command{
 		}
 
 		op.Phase("Importing sections")
-		_, err = runSyncStatus(ctx, fmt.Sprintf("Importing %d sections...", len(filtered)), func(ctx context.Context) (struct{}, error) {
+		_, err = runSyncStatus(ctx, fmt.Sprintf("Importing %d sections...", len(filtered)), quiet, func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, m.ImportSections(ctx, filtered, false)
 		})
 		if err != nil {

--- a/cmd/sync/sync_shared_steps.go
+++ b/cmd/sync/sync_shared_steps.go
@@ -44,6 +44,7 @@ var sharedStepsCmd = &cobra.Command{
 		compareField, _ := cmd.Flags().GetString("compare-field")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		autoApprove, _ := cmd.Flags().GetBool("approve")
+		quiet := isQuiet(cmd)
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
 		autoSaveFiltered, _ := cmd.Flags().GetBool("save-filtered")
 
@@ -91,11 +92,11 @@ var sharedStepsCmd = &cobra.Command{
 		}
 		defer m.Close()
 
-		op := newSyncOperation("Sync shared steps")
+		op := newSyncOperation("Sync shared steps", quiet)
 		defer op.Finish()
 
 		op.Phase("Loading shared steps")
-		loadedSteps, err := runSyncStatus(ctx, "Loading shared steps...", func(ctx context.Context) (struct {
+		loadedSteps, err := runSyncStatus(ctx, "Loading shared steps...", quiet, func(ctx context.Context) (struct {
 			Source data.GetSharedStepsResponse
 			Target data.GetSharedStepsResponse
 		}, error) {
@@ -119,7 +120,7 @@ var sharedStepsCmd = &cobra.Command{
 
 		// Шаг 2) Получение кейсов source для определения использования shared steps
 		op.Phase("Loading source cases")
-		sourceCases, err := runSyncStatus(ctx, "Loading source cases...", func(ctx context.Context) (data.GetCasesResponse, error) {
+		sourceCases, err := runSyncStatus(ctx, "Loading source cases...", quiet, func(ctx context.Context) (data.GetCasesResponse, error) {
 			return m.Client.GetCases(ctx, srcProject, srcSuite, 0)
 		})
 		if err != nil {
@@ -163,7 +164,7 @@ var sharedStepsCmd = &cobra.Command{
 
 		// Шаг 5) Импорт
 		op.Phase("Importing shared steps")
-		_, err = runSyncStatus(ctx, fmt.Sprintf("Importing %d shared steps...", len(filtered)), func(ctx context.Context) (struct{}, error) {
+		_, err = runSyncStatus(ctx, fmt.Sprintf("Importing %d shared steps...", len(filtered)), quiet, func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, m.ImportSharedSteps(ctx, filtered, false)
 		})
 		if err != nil {

--- a/cmd/sync/sync_suites.go
+++ b/cmd/sync/sync_suites.go
@@ -42,6 +42,7 @@ var suitesCmd = &cobra.Command{
 		dstProject, _ := cmd.Flags().GetInt64("dst-project")
 		compareField, _ := cmd.Flags().GetString("compare-field")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		quiet := isQuiet(cmd)
 		autoApprove, _ := cmd.Flags().GetBool("approve")
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
 
@@ -59,11 +60,11 @@ var suitesCmd = &cobra.Command{
 		}
 		defer m.Close()
 
-		op := newSyncOperation("Sync suites")
+		op := newSyncOperation("Sync suites", quiet)
 		defer op.Finish()
 
 		op.Phase("Loading suites")
-		loaded, err := runSyncStatus(ctx, "Loading suites...", func(ctx context.Context) (struct {
+		loaded, err := runSyncStatus(ctx, "Loading suites...", quiet, func(ctx context.Context) (struct {
 			Source data.GetSuitesResponse
 			Target data.GetSuitesResponse
 		}, error) {
@@ -116,7 +117,7 @@ var suitesCmd = &cobra.Command{
 
 		// Шаг 3) Подтверждение и импорт
 		op.Phase("Importing suites")
-		_, err = runSyncStatus(ctx, fmt.Sprintf("Importing %d suites...", len(filtered)), func(ctx context.Context) (struct{}, error) {
+		_, err = runSyncStatus(ctx, fmt.Sprintf("Importing %d suites...", len(filtered)), quiet, func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, m.ImportSuites(ctx, filtered, false)
 		})
 		if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -179,7 +179,9 @@ func updateProjectInteractive(cli client.ClientInterface, cmd *cobra.Command, id
 		return fmt.Errorf("failed to update project: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Project updated (ID: %d)", project.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Project updated (ID: %d)", project.ID)
+	}
 	return outputUpdateResult(cmd, project)
 }
 
@@ -215,7 +217,9 @@ func updateSuiteInteractive(cli client.ClientInterface, cmd *cobra.Command, id i
 		return fmt.Errorf("failed to update suite: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Suite updated (ID: %d)", suite.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Suite updated (ID: %d)", suite.ID)
+	}
 	return outputUpdateResult(cmd, suite)
 }
 
@@ -252,7 +256,9 @@ func updateCaseInteractive(cli client.ClientInterface, cmd *cobra.Command, id in
 		return fmt.Errorf("failed to update case: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Case updated (ID: %d)", caseResp.ID)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Case updated (ID: %d)", caseResp.ID)
+	}
 	return outputUpdateResult(cmd, caseResp)
 }
 
@@ -614,7 +620,9 @@ func outputUpdateResult(cmd *cobra.Command, data interface{}) error {
 // updateLabels обновляет метки теста (DEPRECATED: use 'gotr labels update' instead)
 func updateLabels(cli client.ClientInterface, cmd *cobra.Command, testID int64) error {
 	ctx := cmd.Context()
-	fmt.Fprintln(os.Stderr, "⚠️  WARNING: 'gotr update labels' is deprecated. Use 'gotr labels update test' instead.")
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		fmt.Fprintln(os.Stderr, "⚠️  WARNING: 'gotr update labels' is deprecated. Use 'gotr labels update test' instead.")
+	}
 
 	labelsFlag, _ := cmd.Flags().GetString("labels")
 	if labelsFlag == "" {
@@ -639,7 +647,9 @@ func updateLabels(cli client.ClientInterface, cmd *cobra.Command, testID int64) 
 		return fmt.Errorf("failed to update labels: %w", err)
 	}
 
-	ui.Successf(os.Stdout, "Labels updated for test %d: %v", testID, labels)
+	if quiet, _ := cmd.Flags().GetBool("quiet"); !quiet {
+		ui.Successf(os.Stdout, "Labels updated for test %d: %v", testID, labels)
+	}
 	return nil
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -489,10 +489,6 @@ gotr/
 │   │   ├── dryrun.go          #     DryRunPrinter
 │   │   ├── filename.go        #     GenerateTimestamp, BuildFilename
 │   │   └── paths.go           #     GetExportsDir, EnsureDir
-│   ├── progress/               #   Прогресс-бары (mpb)
-│   │   ├── progress.go        #     ProgressManager
-│   │   ├── monitor.go         #     WithMonitorCtx
-│   │   └── async.go           #     Async helpers
 │   ├── interactive/            #   Интерактивный выбор
 │   │   ├── interactive.go     #     SelectProject, SelectSuite, SelectRun
 │   │   └── wizard.go          #     InteractiveWizard

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,544 +1,117 @@
-# Progress Runtime System
+# Система прогресса в gotr
 
-## Overview
+> Актуально на 2026-03-19 (после Stage 10.5/11.0).
 
-Current progress/status flow in `gotr` is built on `internal/ui` runtime (`RunWithStatus`, `Operation`, `TaskHandle`).
-Legacy `internal/progress` and mpb-based bars were removed.
+## Кратко
 
-## Key Features
+В проекте используется **единый runtime прогресса** из `internal/ui`.
 
-- **Universal**: Works with any method that supports progress reporting
-- **Non-blocking**: Channel-based updates don't block execution
-- **Thread-safe**: Safe to use from multiple goroutines
-- **Decoupled**: Business logic knows nothing about UI
-- **Flexible**: Can be used with progress bars, logs, or any other UI
-- **Multi-bar Support**: Multiple progress bars render simultaneously on separate lines
+- Основной API: `ui.RunWithStatus(...)`, `ui.NewOperation(...)`, `TaskHandle`.
+- Runtime работает с `context.Context` (Ctrl+C/timeout отменяют операции корректно).
+- Для параллельных загрузок используется контракт `concurrency.ProgressReporter` / `concurrency.PaginatedProgressReporter`.
+- Команды не должны напрямую реализовывать рендер прогресса на уровне низкоуровневых баров.
 
-## Architecture
+Legacy-пакет `internal/progress` и старые mpb-сценарии больше не являются текущим runtime-контрактом.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         Business Logic                           │
-│  ┌─────────────────────┐    ┌─────────────────────┐             │
-│  │   GetCasesParallel  │    │  GetSuitesParallel  │             │
-│  │  (accepts Monitor)  │    │  (accepts Monitor)  │             │
-│  └──────────┬──────────┘    └──────────┬──────────┘             │
-│             │                          │                        │
-│             ▼                          ▼                        │
-│  ┌──────────────────────────────────────────┐                   │
-│  │         WorkerPool with Monitor           │                   │
-│  │  (calls monitor.Increment() after task)   │                   │
-│  └──────────┬───────────────────────────────┘                   │
-└─────────────┼──────────────────────────────────────────────────┘
-              │ sends to channel
-              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     UI / Progress Layer                          │
-│  ┌─────────────────────┐    ┌─────────────────────┐             │
-│  │    progress.Bar     │    │      Logger         │             │
-│  │  (receives updates) │    │  (receives updates) │             │
-│  └─────────────────────┘    └─────────────────────┘             │
-│                                                                  │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │              mpb.Progress Container                      │   │
-│  │         (manages multiple bars rendering)               │   │
-│  └─────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────┘
-```
+## Архитектурная роль
 
-## Components
+Поток данных:
 
-### 1. Manager
+1. `cmd/*` создаёт operation/task через `internal/ui`.
+2. Клиент/конкурентный слой получает reporter (`TaskHandle`) через конфиг.
+3. Concurrency-слой отправляет события прогресса (`OnItemComplete`, `OnBatchReceived`, `OnPageFetched`, `OnError`).
+4. UI-runtime показывает прогресс и итоговые статусы.
 
-The `Manager` creates and manages an `mpb.Progress` container which handles all progress bars:
+## Основные сущности
+
+### 1) `ui.RunWithStatus`
+
+Высокоуровневый helper для операций с фазами/статусом.
 
 ```go
-type Manager struct {
-    progress *mpb.Progress
-    output   io.Writer
-    quiet    bool
-    enabled  bool
-    wg       sync.WaitGroup
-}
-```
-
-**Key Methods:**
-- `NewManager(opts ...Option)` - Creates a new manager with mpb container
-- `NewBar(total int64, description string) *Bar` - Creates a new progress bar
-- `NewSpinner(description string) *Bar` - Creates a spinner for indeterminate operations
-- `Wait()` - Waits for all bars to complete
-
-### 2. Bar
-
-The `Bar` type represents a single progress bar with methods called directly on the object:
-
-```go
-type Bar struct {
-    bar    *mpb.Bar
-    total  int64
-    mgr    *Manager
-}
-```
-
-**Key Methods (called on bar object):**
-- `bar.Add(n)` - Increment by n
-- `bar.Increment()` - Increment by 1
-- `bar.Finish()` - Complete the bar
-- `bar.Describe(description)` - Update description
-
-### 3. Monitor
-
-The `Monitor` type tracks progress and sends updates through a channel:
-
-```go
-type Monitor struct {
-    ProgressChan chan<- int  // Channel for updates
-    Total        int         // Expected total
-    completed    int64       // Atomic counter
-}
-```
-
-**Key Methods:**
-- `Increment()` - Increment by 1 (thread-safe, non-blocking)
-- `IncrementBy(n)` - Increment by n
-- `Completed()` - Get completed count
-- `Percentage()` - Get completion percentage
-
-### 4. WorkerPool Integration
-
-The `concurrent.WorkerPool` automatically calls `monitor.Increment()` after each task completes:
-
-```go
-pool := concurrent.NewWorkerPool(
-    concurrent.WithMaxWorkers(5),
-    concurrent.WithRateLimit(150),
-    concurrent.WithProgressMonitor(monitor),  // Optional
-)
-```
-
-### 5. Client Methods
-
-All parallel client methods accept an optional `ProgressMonitor`:
-
-```go
-func (c *HTTPClient) GetCasesParallel(
-    projectID int64, 
-    suiteIDs []int64, 
-    workers int, 
-    monitor ProgressMonitor,  // Can be nil
-) (map[int64]data.GetCasesResponse, error)
-```
-
-## Usage Examples
-
-### Basic Example with Progress Bar
-
-```go
-package main
-
-import (
-    "github.com/Korrnals/gotr/internal/client"
-    "github.com/Korrnals/gotr/internal/ui"
-)
-
-func main() {
-    cli := client.NewHTTPClient(...)
-    
-    // Status runtime for the operation
-    _, err := ui.RunWithStatus(context.Background(), ui.StatusConfig{
-        Title: "Loading cases...",
-    }, func(ctx context.Context) (struct{}, error) {
-        // Execute with progress tracking
-        _, err := cli.GetCasesParallel(30, suiteIDs, 5, monitor)
-        return struct{}{}, err
-    })
-    
-    // Create monitor with channel
-    progressChan := make(chan int, 100)
-    monitor := progress.NewMonitor(progressChan, len(suiteIDs))
-    
-    // Goroutine to update progress bar (method on bar object)
-    go func() {
-        for range progressChan {
-            bar.Increment()  // Called on bar, not package
-        }
-    }()
-    
-    // Execute with progress tracking
-    cases, err := cli.GetCasesParallel(30, suiteIDs, 5, monitor)
-    if err != nil {
-        log.Fatal(err)
-    }
-    
-    // Finish the bar (method on bar object)
-    bar.Finish()
-    
-    // Wait for all bars to complete
-    pm.Wait()
-    
-    // Use results...
-    fmt.Printf("Loaded %d cases\n", len(cases))
-}
-```
-
-### Two-Phase Progress with Multiple Bars
-
-With mpb, multiple bars render simultaneously on separate lines:
-
-```go
-func compareCasesWithProgress(cli client.ClientInterface, pid1, pid2 int64) {
-    pm := progress.NewManager()
-    
-    // Phase 1: Spinner for getting suites
-    spinner := pm.NewSpinner("Getting suites list...")
-    suitesMap, err := cli.GetSuitesParallel([]int64{pid1, pid2}, 2, nil)
-    spinner.Finish()  // Method on bar object
-    
-    // Phase 2: Two progress bars render simultaneously (mpb feature)
-    totalSuites := len(suitesMap[pid1]) + len(suitesMap[pid2])
-    bar := pm.NewBar(int64(totalSuites), "Loading cases...")
-    
-    progressChan := make(chan int, totalSuites)
-    monitor := progress.NewMonitor(progressChan, totalSuites)
-    
-    go func() {
-        for range progressChan {
-            bar.Increment()  // Method on bar object
-        }
-    }()
-    
-    // Both projects load in parallel with shared progress
-    var wg sync.WaitGroup
-    wg.Add(2)
-    
-    go func() {
-        defer wg.Done()
-        cli.GetCasesParallel(pid1, suiteIDs1, 5, monitor)
-    }()
-    
-    go func() {
-        defer wg.Done()
-        cli.GetCasesParallel(pid2, suiteIDs2, 5, monitor)
-    }()
-    
-    wg.Wait()
-    bar.Finish()  // Method on bar object
-    
-    // Wait for all bars to render
-    pm.Wait()
-}
-```
-
-### Multiple Simultaneous Progress Bars
-
-mpb supports multiple bars rendering at the same time:
-
-```go
-func loadMultipleProjects(cli client.ClientInterface, projectIDs []int64) {
-    pm := progress.NewManager()
-    
-    // Each bar renders on its own line
-    bars := make(map[int64]*progress.Bar)
-    for _, pid := range projectIDs {
-        bars[pid] = pm.NewBar(100, fmt.Sprintf("Project %d", pid))
-    }
-    
-    var wg sync.WaitGroup
-    for _, pid := range projectIDs {
-        wg.Add(1)
-        go func(id int64) {
-            defer wg.Done()
-            // Work...
-            for i := 0; i < 100; i++ {
-                bars[id].Increment()  // Each bar updated independently
-                time.Sleep(10 * time.Millisecond)
-            }
-            bars[id].Finish()
-        }(pid)
-    }
-    
-    wg.Wait()
-    pm.Wait()
-}
-```
-
-### Without Progress (Backwards Compatible)
-
-```go
-// Simply pass nil as monitor
-cases, err := cli.GetCasesParallel(30, suiteIDs, 5, nil)
-```
-
-## Interface Design
-
-### Why Interface?
-
-The `ProgressMonitor` interface allows:
-1. **Testing** - Easy to mock
-2. **Flexibility** - Different implementations (silent, logging, etc.)
-3. **Decoupling** - Client doesn't depend on progress package
-
-```go
-// In client/interfaces.go
-type ProgressMonitor interface {
-    Increment()
-}
-
-// In progress/monitor.go - full implementation
-type Monitor struct {
-    ProgressChan chan<- int
-    Total        int
-    completed    int64
-}
-
-func (m *Monitor) Increment() { ... }
-func (m *Monitor) IncrementBy(n int) { ... }
-```
-
-## Best Practices
-
-1. **Always use buffered channels** to avoid blocking:
-   ```go
-   progressChan := make(chan int, 100)  // Buffer = number of expected updates
-   ```
-
-2. **Close the channel** when done:
-   ```go
-   defer close(progressChan)
-   ```
-
-3. **Handle nil gracefully** - methods should work with `monitor = nil`:
-   ```go
-   if monitor != nil {
-       monitor.Increment()
-   }
-   ```
-
-4. **Update UI in separate goroutine** to avoid blocking workers:
-   ```go
-   go func() {
-       for range progressChan {
-           bar.Increment()  // Method on bar object
-       }
-   }()
-   ```
-
-5. **Use appropriate buffer size** based on expected number of tasks
-
-6. **Call pm.Wait()** at the end to ensure all bars finish rendering:
-   ```go
-   pm := progress.NewManager()
-   // ... create and use bars ...
-   pm.Wait()  // Wait for mpb to finish rendering
-   ```
-
-## Migration to ui Runtime
-
-### Package Import Change
-
-**Old:**
-```go
-import "github.com/schollz/progressbar/v3"
-```
-
-**New:**
-```go
-import "github.com/Korrnals/gotr/internal/ui"
-```
-
-### API Changes
-
-**Old (progressbar/v3):**
-```go
-bar := progressbar.NewOptions64(total, ...)
-progress.Add(bar, 1)        // Package function
-progress.Finish(bar)        // Package function
-```
-
-**New (ui runtime):**
-```go
-_, err := ui.RunWithStatus(ctx, ui.StatusConfig{Title: "Description"}, func(ctx context.Context) (struct{}, error) {
-    // do work
+_, err := ui.RunWithStatus(ctx, ui.StatusConfig{
+    Title: "Loading data",
+}, func(ctx context.Context) (struct{}, error) {
+    // long-running work
     return struct{}{}, nil
 })
 ```
 
-### Key Differences
+### 2) `ui.Operation`
 
-| Feature | progressbar/v3 | ui runtime |
-|---------|---------------|-----|
-| Library | `github.com/schollz/progressbar/v3` | `internal/ui` |
-| Multiple tasks | Limited | `Operation` + `TaskHandle` |
-| Update API | Package functions | Runtime/task methods |
-| Container | None | `ui.Display` + runtime facade |
-| Wait | Not needed | `Operation.Finish()` |
+Подходит, когда нужно несколько задач в рамках одной операции.
 
-## Comparison with Alternatives
-
-| Approach | Pros | Cons |
-|----------|------|------|
-| **Callback** (old) | Simple | Blocks worker, hard to manage |
-| **Channel + Monitor** (current) | Non-blocking, flexible, clean | Slightly more code |
-| **Context with values** | Standard pattern | Verbose, harder to type-safe |
-| **Global state** | Easy | Not thread-safe, hard to test |
-
-## Migration Guide
-
-### From Callback to Monitor
-
-**Old:**
 ```go
-onComplete := func(suiteID int64) {
-    bar.Add(1)
+op := ui.NewOperation(ui.StatusConfig{Title: "Compare cases"})
+defer op.Finish()
+
+task := op.AddTask("Project 30", 12)
+// task реализует ProgressReporter/PaginatedProgressReporter
+```
+
+### 3) `TaskHandle` как reporter
+
+`TaskHandle` передаётся в `concurrency.ControllerConfig.Reporter` или `FetchParallel*`-опции.
+
+```go
+cfg := &concurrency.ControllerConfig{
+    MaxConcurrentSuites: 10,
+    MaxConcurrentPages:  6,
+    Timeout:             30 * time.Minute,
+    Reporter:            task,
 }
-cases, err := cli.GetCasesParallelWithCallback(pid, suites, 5, onComplete)
 ```
 
-**New:**
-```go
-progressChan := make(chan int, len(suites))
-monitor := progress.NewMonitor(progressChan, len(suites))
+## Как это используется в compare
 
-go func() {
-    for range progressChan {
-        bar.Increment()  // Method on bar object
-    }
-}()
+### `compare cases`
 
-cases, err := cli.GetCasesParallel(pid, suites, 5, monitor)
-```
+- Использует heavy runtime (`GetCasesParallelCtx`) + `TaskHandle` reporter.
+- Поддерживает timeout/cancel/retry/failed pages flow.
 
-## User Experience
+### `compare sections` (Stage 11)
 
-Система прогресса использует эмодзи и понятные сообщения для лучшего UX:
+- Переведён на adapter-path (`GetSectionsParallelCtx`) с тем же runtime-конфигом heavy compare.
+- Командный слой больше не должен реализовывать собственные suite/page loop.
 
-```
-🔍 Получение структуры проектов 30 и 34...
+## Конфигурация heavy compare runtime
 
-📥 Параллельная загрузка данных:
-   Проект 30: 15 сьютов | Проект 34: 16 сьютов
+Единый профиль для heavy-команд (`cases`, `sections`):
 
-⏳ Проект 30 (15 сьютов)...  [███████████████░░░░░]  75%  (12/15, 45 items/min) [2m15s:30s]
-⏳ Проект 34 (16 сьютов)...  [████████████████░░░░]  80%  (13/16, 38 items/min) [5m12s:15s]
+- `--parallel-suites`
+- `--parallel-pages`
+- `--page-retries`
+- `--rate-limit`
+- `--timeout`
 
-📊 Результаты загрузки:
-  ✅ Проект 30: 15 сьютов → 1854 кейсов (3m15s)
-  ✅ Проект 34: 16 сьютов → 24073 кейсов (8m42s)
+Источники значений:
 
-🔍 Выполняется анализ и сверка данных...
-  ✅ Анализ завершён (125ms)
+1. Флаги команды (приоритет выше)
+2. Viper-конфиг (`compare.*`, `compare.cases.*`)
+3. Default значения
 
-Результат сохранён: /home/user/.gotr/exports/compare/compare_2026-02-21_01-00-48.json
+## Правила для нового кода
 
-┌──────────────────────────────────────────────────────────────┐
-│          📊 СТАТИСТИКА: cases                                │
-├──────────────────────────────────────────────────────────────┤
-│  ⏱️  Время выполнения: 11m48s                                │
-│  📦 Всего обработано: 36425                                  │
-├──────────────────────────────────────────────────────────────┤
-│  ✅ Только в проекте 30: 1854                                │
-│  ✅ Только в проекте 34: 24073                               │
-│  🔗 Общих: 10498                                             │
-└──────────────────────────────────────────────────────────────┘
-```
+1. Для долгих операций использовать только `internal/ui` runtime.
+2. В `cmd/*` не писать кастомные рендереры прогресса и не дублировать concurrency loops.
+3. Прогресс должен строиться через reporter-контракты concurrency.
+4. Всегда прокидывать `ctx` до client/concurrency слоя.
+5. Ошибки отмены (`context.Canceled`, `context.DeadlineExceeded`) обрабатывать как штатный сценарий.
 
-### Отладочный режим
+## Проверка после изменений
 
-При использовании флага `--debug` выводится подробная отладочная информация:
+Минимальный чек:
 
-```bash
-gotr compare cases --pid1 30 --pid2 34 --debug
-```
+1. `go test ./cmd/compare/...`
+2. `go test ./internal/client/...`
+3. `go test ./...`
+4. Smoke:
+   - `gotr compare cases --pid1 <id> --pid2 <id>`
+   - `gotr compare sections --pid1 <id> --pid2 <id>`
+   - Ctrl+C во время загрузки не печатает шум и завершает операцию корректно
 
-Пример вывода с `--debug`:
-```
-2026/02/20 23:38:52 [DEBUG] [Compare] Fetching suites for projects 30 and 34
-2026/02/20 23:38:52 [DEBUG] [Compare] Found suites: P30=15, P34=16, total=31
-...
-2026/02/20 23:38:55 [DEBUG] [Project 30] Processing suite 12345: 150 cases
-2026/02/20 23:38:56 [DEBUG] [Project 30] Returning 1854 unique cases
-```
+## Связанные документы
 
-### Значения эмодзи
-
-| Эмодзи | Значение |
-|--------|----------|
-| 🔍 | Поиск / Получение структуры |
-| 📥 | Загрузка данных |
-| ⏳ | Ожидание / Выполнение |
-| 📊 | Статистика / Результат |
-| ✅ | Успешно / Только в проекте |
-| 🔗 | Общие / Связанные |
-| ⏱️ | Время выполнения |
-| 📦 | Всего обработано |
-
-## Performance Optimizations
-
-### Parallel Pagination
-
-Для ускорения загрузки больших сьютов (>250 кейсов) используется параллельная пагинация:
-
-```
-Без оптимизации:  page1 → wait → page2 → wait → page3 ... (последовательно)
-С оптимизацией:   page1 → [page2, page3, page4, page5] ... (параллельно, max 5 concurrent)
-```
-
-Настройки в `internal/client/cases.go`:
-- `maxConcurrency = 5` - максимум параллельных запросов страниц
-- `limit = 250` - размер страницы (максимум TestRail)
-
-### Parallel Project Loading
-
-Оба проекта загружаются параллельно с отдельными прогресс-барами (mpb renders them on separate lines):
-
-```go
-// Project 1
-go func() {
-    cases1, err1 = fetchCasesForProjectWithStats(...)
-}()
-
-// Project 2  
-go func() {
-    cases2, err2 = fetchCasesForProjectWithStats(...)
-}()
-```
-
-### Rate Limiting
-
-TestRail API ограничен 180 req/min. Все запросы проходят через rate limiter:
-- Burst: 20 запросов
-- Rate: 3 запроса/сек
-
-## Future Enhancements
-
-- [x] Support for multiple simultaneous progress bars (mpb)
-- [x] Pipeline-параллелизация загрузки кейсов (`internal/concurrency`)
-- [x] Централизованный reporter для compare-команд (`pkg/reporter`)
-- [x] ANSI live display с динамическими задачами (`internal/ui/display.go`)
-- [x] FetchParallel[T] / FetchParallelBySuite[T] — унифицированные стратегии (Stage 6.8)
-- [x] Generic compare factory `newSimpleCompareCmd` (Stage 6.8)
-- [ ] Support for cancellable contexts
-- [ ] Progress reporting with item counts (not just increments)
-- [ ] Support for nested progress (parent/child bars)
-- [ ] Integration with OpenTelemetry for distributed tracing
-
-## Архитектура вывода прогресса
-
-### sync/get команды → `internal/ui/runtime.go`
-`RunWithStatus` и `Operation` обеспечивают единый статус/прогресс runtime.
-
-### compare cases → `internal/ui/display.go` (ANSI live display)
-Динамическая таблица со статусами задач, обновляется в реальном времени.
-
-### compare * (13 подкоманд) → `pkg/reporter/` (builder pattern)
-Централизованный вывод статистики через `reporter.New().Сection().Stat().Print()`.
-Заменяет устаревший progress.Manager в compare-командах.
-
-## Related Packages
-
-- `internal/concurrent` - Worker pool with progress support
-- `internal/ui/runtime.go` - Unified progress runtime for commands
-- `internal/concurrency` - Unified concurrency strategies (FetchParallel[T], FetchParallelBySuite[T], ParallelController)
-- `internal/ui` - ANSI live display (compare cases)
-- `pkg/reporter` - Builder pattern for statistics output (ANSI + go-pretty)
-- `internal/client` - HTTP client with progress-aware methods
+- `docs/architecture.md`
+- `.github/instructions/STAGE_11.0_DESIGN.md`
+- `.github/instructions/PLAN.md`

--- a/internal/client/interfaces.go
+++ b/internal/client/interfaces.go
@@ -68,6 +68,8 @@ type SuitesAPI interface {
 // SectionsAPI — операции с секциями
 type SectionsAPI interface {
 	GetSections(ctx context.Context, projectID, suiteID int64) (data.GetSectionsResponse, error)
+	// GetSectionsParallelCtx gets sections for multiple suites using shared concurrency runtime controls.
+	GetSectionsParallelCtx(ctx context.Context, projectID int64, suiteIDs []int64, config *concurrency.ControllerConfig) (data.GetSectionsResponse, error)
 	GetSection(ctx context.Context, sectionID int64) (*data.Section, error)
 	AddSection(ctx context.Context, projectID int64, req *data.AddSectionRequest) (*data.Section, error)
 	UpdateSection(ctx context.Context, sectionID int64, req *data.UpdateSectionRequest) (*data.Section, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -51,11 +51,12 @@ type MockClient struct {
 	// ConcurrentAPI - Parallel methods (Stage 6.2)
 
 	// SectionsAPI
-	GetSectionsFunc   func(ctx context.Context, projectID, suiteID int64) (data.GetSectionsResponse, error)
-	GetSectionFunc    func(ctx context.Context, sectionID int64) (*data.Section, error)
-	AddSectionFunc    func(ctx context.Context, projectID int64, req *data.AddSectionRequest) (*data.Section, error)
-	UpdateSectionFunc func(ctx context.Context, sectionID int64, req *data.UpdateSectionRequest) (*data.Section, error)
-	DeleteSectionFunc func(ctx context.Context, sectionID int64) error
+	GetSectionsFunc            func(ctx context.Context, projectID, suiteID int64) (data.GetSectionsResponse, error)
+	GetSectionsParallelCtxFunc func(ctx context.Context, projectID int64, suiteIDs []int64, config *concurrency.ControllerConfig) (data.GetSectionsResponse, error)
+	GetSectionFunc             func(ctx context.Context, sectionID int64) (*data.Section, error)
+	AddSectionFunc             func(ctx context.Context, projectID int64, req *data.AddSectionRequest) (*data.Section, error)
+	UpdateSectionFunc          func(ctx context.Context, sectionID int64, req *data.UpdateSectionRequest) (*data.Section, error)
+	DeleteSectionFunc          func(ctx context.Context, sectionID int64) error
 
 	// SharedStepsAPI
 	GetSharedStepsFunc       func(ctx context.Context, projectID int64) (data.GetSharedStepsResponse, error)
@@ -432,6 +433,27 @@ func (m *MockClient) GetSections(ctx context.Context, projectID, suiteID int64) 
 		return m.GetSectionsFunc(ctx, projectID, suiteID)
 	}
 	return nil, nil
+}
+
+func (m *MockClient) GetSectionsParallelCtx(ctx context.Context, projectID int64, suiteIDs []int64, config *concurrency.ControllerConfig) (data.GetSectionsResponse, error) {
+	if m.GetSectionsParallelCtxFunc != nil {
+		return m.GetSectionsParallelCtxFunc(ctx, projectID, suiteIDs, config)
+	}
+
+	if len(suiteIDs) == 0 {
+		return m.GetSections(ctx, projectID, 0)
+	}
+
+	all := make(data.GetSectionsResponse, 0)
+	for _, suiteID := range suiteIDs {
+		sections, err := m.GetSections(ctx, projectID, suiteID)
+		if err != nil {
+			return all, err
+		}
+		all = append(all, sections...)
+	}
+
+	return all, nil
 }
 
 func (m *MockClient) GetSection(ctx context.Context, sectionID int64) (*data.Section, error) {

--- a/internal/client/sections.go
+++ b/internal/client/sections.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
+	"github.com/Korrnals/gotr/internal/concurrency"
+	"github.com/Korrnals/gotr/internal/concurrent"
 	"github.com/Korrnals/gotr/internal/models/data"
 )
 
@@ -25,6 +28,91 @@ func (c *HTTPClient) GetSections(ctx context.Context, projectID, suiteID int64) 
 		return nil, fmt.Errorf("request error GetSections for project %d, suite %d: %w", projectID, suiteID, err)
 	}
 	return data.GetSectionsResponse(sections), nil
+}
+
+// GetSectionsParallelCtx gets sections from multiple suites with shared runtime controls.
+// If suiteIDs is empty, it falls back to unfiltered sections request (suite_id=0).
+func (c *HTTPClient) GetSectionsParallelCtx(
+	ctx context.Context,
+	projectID int64,
+	suiteIDs []int64,
+	config *concurrency.ControllerConfig,
+) (data.GetSectionsResponse, error) {
+	if config == nil {
+		config = concurrency.DefaultControllerConfig()
+	} else {
+		config.Validate()
+	}
+
+	if config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, config.Timeout)
+		defer cancel()
+	}
+
+	if len(suiteIDs) == 0 {
+		return c.GetSections(ctx, projectID, 0)
+	}
+
+	var limiter *concurrent.AdaptiveRateLimiter
+	if config.RequestsPerMinute > 0 {
+		limiter = concurrent.NewAdaptiveRateLimiter(config.RequestsPerMinute)
+	}
+
+	maxRetries := config.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+
+	opts := []concurrency.FetchOption{
+		concurrency.WithContinueOnError(),
+		concurrency.WithMaxConcurrency(config.MaxConcurrentSuites),
+	}
+	if config.Reporter != nil {
+		opts = append(opts, concurrency.WithReporter(config.Reporter))
+	}
+
+	sections, err := concurrency.FetchParallelBySuite(ctx, suiteIDs,
+		func(suiteID int64) ([]data.Section, error) {
+			if limiter != nil {
+				if waitErr := limiter.WaitCtx(ctx); waitErr != nil {
+					return nil, waitErr
+				}
+			}
+
+			var lastErr error
+			for attempt := 0; attempt <= maxRetries; attempt++ {
+				sections, fetchErr := c.GetSections(ctx, projectID, suiteID)
+				if fetchErr == nil {
+					return sections, nil
+				}
+
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+
+				lastErr = fetchErr
+				if attempt == maxRetries {
+					break
+				}
+
+				delay := time.Duration(100*(1<<attempt)) * time.Millisecond
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(delay):
+				}
+			}
+
+			return nil, lastErr
+		},
+		opts...,
+	)
+	if err != nil && len(sections) == 0 {
+		return nil, err
+	}
+
+	return data.GetSectionsResponse(sections), err
 }
 
 // GetSection — получает одну секцию по ID

--- a/internal/client/sections_test.go
+++ b/internal/client/sections_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/Korrnals/gotr/internal/concurrency"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/stretchr/testify/assert"
 )
@@ -251,4 +253,89 @@ func TestDeleteSection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSectionsParallelCtx_BySuites(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.String(), "get_sections/30")
+
+		suiteID := r.URL.Query().Get("suite_id")
+		var payload map[string]any
+		switch suiteID {
+		case "100":
+			payload = map[string]any{"offset": 0, "limit": 250, "size": 1, "sections": []map[string]any{{"id": 1, "suite_id": 100, "name": "S-100"}}}
+		case "200":
+			payload = map[string]any{"offset": 0, "limit": 250, "size": 1, "sections": []map[string]any{{"id": 2, "suite_id": 200, "name": "S-200"}}}
+		default:
+			payload = map[string]any{"offset": 0, "limit": 250, "size": 0, "sections": []map[string]any{}}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(payload)
+	}
+
+	client, server := mockClient(t, handler)
+	defer server.Close()
+
+	got, err := client.GetSectionsParallelCtx(
+		context.Background(),
+		30,
+		[]int64{100, 200},
+		&concurrency.ControllerConfig{MaxConcurrentSuites: 2, Timeout: 2 * time.Second},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+}
+
+func TestGetSectionsParallelCtx_EmptySuitesFallback(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.String(), "get_sections/30")
+		assert.Equal(t, "", r.URL.Query().Get("suite_id"))
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"offset":   0,
+			"limit":    250,
+			"size":     1,
+			"sections": []map[string]any{{"id": 10, "name": "Common"}},
+		})
+	}
+
+	client, server := mockClient(t, handler)
+	defer server.Close()
+
+	got, err := client.GetSectionsParallelCtx(context.Background(), 30, nil, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, int64(10), got[0].ID)
+}
+
+func TestGetSectionsParallelCtx_Timeout(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(80 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"offset":   0,
+			"limit":    250,
+			"size":     1,
+			"sections": []map[string]any{{"id": 1, "suite_id": 100, "name": "Late"}},
+		})
+	}
+
+	client, server := mockClient(t, handler)
+	defer server.Close()
+
+	_, err := client.GetSectionsParallelCtx(
+		context.Background(),
+		30,
+		[]int64{100},
+		&concurrency.ControllerConfig{MaxConcurrentSuites: 1, Timeout: 10 * time.Millisecond},
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "deadline")
 }

--- a/internal/ui/display.go
+++ b/internal/ui/display.go
@@ -51,6 +51,17 @@ type Display struct {
 	quiet     bool
 }
 
+var messageQuiet atomic.Bool
+
+// SetMessageQuiet enables/disables static service messages (Info/Success/Warning, etc.).
+func SetMessageQuiet(quiet bool) {
+	messageQuiet.Store(quiet)
+}
+
+func isMessageQuiet() bool {
+	return messageQuiet.Load()
+}
+
 // DisplayOption configures a Display.
 type DisplayOption func(*Display)
 
@@ -112,8 +123,10 @@ func (d *Display) AddTask(name string, total int) *Task {
 func (d *Display) Finish() {
 	if atomic.CompareAndSwapInt32(&d.stopped, 0, 1) {
 		close(d.done)
-		d.render() // final frame
-		fmt.Fprintln(d.w)
+		if !d.quiet {
+			d.render() // final frame
+			fmt.Fprintln(d.w)
+		}
 	}
 }
 
@@ -312,26 +325,50 @@ func fmtCount(n int64) string {
 // ---------------------------------------------------------------------------
 
 // Info prints an informational message.
-func Info(w io.Writer, msg string) { fmt.Fprintf(w, "ℹ️  %s\n", msg) }
+func Info(w io.Writer, msg string) {
+	if isMessageQuiet() {
+		return
+	}
+	fmt.Fprintf(w, "ℹ️  %s\n", msg)
+}
 
 // Infof prints a formatted informational message.
 func Infof(w io.Writer, format string, args ...any) {
+	if isMessageQuiet() {
+		return
+	}
 	fmt.Fprintf(w, "ℹ️  %s\n", fmt.Sprintf(format, args...))
 }
 
 // Success prints a success message.
-func Success(w io.Writer, msg string) { fmt.Fprintf(w, "✅ %s\n", msg) }
+func Success(w io.Writer, msg string) {
+	if isMessageQuiet() {
+		return
+	}
+	fmt.Fprintf(w, "✅ %s\n", msg)
+}
 
 // Successf prints a formatted success message.
 func Successf(w io.Writer, format string, args ...any) {
+	if isMessageQuiet() {
+		return
+	}
 	fmt.Fprintf(w, "✅ %s\n", fmt.Sprintf(format, args...))
 }
 
 // Warning prints a warning message.
-func Warning(w io.Writer, msg string) { fmt.Fprintf(w, "⚠️  %s\n", msg) }
+func Warning(w io.Writer, msg string) {
+	if isMessageQuiet() {
+		return
+	}
+	fmt.Fprintf(w, "⚠️  %s\n", msg)
+}
 
 // Warningf prints a formatted warning message.
 func Warningf(w io.Writer, format string, args ...any) {
+	if isMessageQuiet() {
+		return
+	}
 	fmt.Fprintf(w, "⚠️  %s\n", fmt.Sprintf(format, args...))
 }
 
@@ -339,18 +376,36 @@ func Warningf(w io.Writer, format string, args ...any) {
 func Error(w io.Writer, msg string) { fmt.Fprintf(w, "❌ %s\n", msg) }
 
 // Phase prints a phase transition message.
-func Phase(w io.Writer, msg string) { fmt.Fprintf(w, "🔄 %s\n", msg) }
+func Phase(w io.Writer, msg string) {
+	if isMessageQuiet() {
+		return
+	}
+	fmt.Fprintf(w, "🔄 %s\n", msg)
+}
 
 // Stat prints a statistics line with label and value.
 func Stat(w io.Writer, icon, label string, value interface{}) {
+	if isMessageQuiet() {
+		return
+	}
 	fmt.Fprintf(w, "   %s %s: %v\n", icon, label, value)
 }
 
 // Section prints a section header.
-func Section(w io.Writer, msg string) { fmt.Fprintf(w, "\n📊 %s\n", msg) }
+func Section(w io.Writer, msg string) {
+	if isMessageQuiet() {
+		return
+	}
+	fmt.Fprintf(w, "\n📊 %s\n", msg)
+}
 
 // Cancelled prints a cancellation message.
-func Cancelled(w io.Writer) { fmt.Fprintln(w, "\n❌ Cancelled") }
+func Cancelled(w io.Writer) {
+	if isMessageQuiet() {
+		return
+	}
+	fmt.Fprintln(w, "\n❌ Cancelled")
+}
 
 // PreviewField is a label–value pair for Preview output.
 type PreviewField struct {


### PR DESCRIPTION
## Summary
- add GetSectionsParallelCtx adapter in internal/client
- migrate compare sections to adapter/runtime path
- unify heavy compare runtime config for cases/sections
- keep compare all integration behavior-compatible
- update runtime/progress architecture docs

## Additional modular commit
- isolate quiet/flags hardening as separate commit in same branch (stage13-prep)

## Validation
- go test ./... -count=1
