### PR TITLE
chore: bump version to 3.0.1, add CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@
 
 ---
 
+## [3.0.1] - 2026-04-12
+
+### Fixed
+
+- Removed dead `--soft` flag from `gotr delete` (was declared but never used).
+- Removed misleading milestone/plan/entry references from `gotr add` and `gotr update` help text.
+- Fixed `--save-filtered` flag: wired into `sync full` command to actually save filtered shared steps list after migration.
+- Fixed self-test table alignment for dynamic content widths.
+- Fixed spinner first-frame delay in `ui.RunWithStatus` (immediate render before ticker).
+
+### Added
+
+- Progress spinners for all API-calling commands (~48 commands across cases, attachments, configurations, milestones, plans, groups, labels, run, result, tests, reports, export).
+- Spinner wrapper for `gotr self-test` execution.
+
+### Changed
+
+- Documentation: added missing compare flags (`--include-refs`, `--include-custom-statuses`, `--include-custom-steps`, `--include-updated-by`, `--include-details`) to EN/RU guides.
+- Documentation: corrected CRUD instruction redirects for milestones/plans.
+- Documentation: fixed artifact filenames in migration-shared-steps guide.
+
+---
+
 ## [3.0.0] - 2026-04-09
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// Version is populated at build time via -ldflags.
-	Version = "3.0.0" // default value for local development
+	Version = "3.0.1" // default value for local development
 	Commit  = "unknown"
 	Date    = "unknown"
 	userHomeDir = os.UserHomeDir


### PR DESCRIPTION
## Что сделано

Hotfix PR #26 был смержен без обновления версии. Этот PR добавляет:

- **`cmd/root.go`**: `Version` обновлён с `3.0.0` → `3.0.1`
- **`CHANGELOG.md`**: добавлена секция `[3.0.1] - 2026-04-12` с полным описанием всех изменений хотфикса

## Связано с

- Closes the version gap from PR #26
- Related: Issue #21