### PR TITLE
feat(#30): Navigation hub, AlignedLabels UX system, cross-command dispatcher

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -105,14 +105,14 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 && endpoint != "attachment" {
 		parsedID, err := flags.ValidateRequiredID(args, 1, "ID")
 		if err != nil {
-			return err
+			return fmt.Errorf("runAdd: %w", err)
 		}
 		id = parsedID
 	}
 
 	resolvedID, err := resolveAddParentID(ctx, interactive.PrompterFromContext(ctx), cli, endpoint, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("runAdd: %w", err)
 	}
 	id = resolvedID
 
@@ -153,12 +153,12 @@ var addEndpoints = map[string]addEndpointSpec{
 	"project": {"", func(cli client.ClientInterface, cmd *cobra.Command, _ int64, jsonData []byte) error {
 		return addProject(cli, cmd, jsonData)
 	}},
-	"suite":        {"project_id", addSuite},
-	"section":      {"project_id", addSection},
-	"case":         {"section_id", addCase},
-	"run":          {"project_id", addRun},
-	"result":       {"test_id", addResult},
-	"shared-step":  {"project_id", addSharedStep},
+	"suite":       {"project_id", addSuite},
+	"section":     {"project_id", addSection},
+	"case":        {"section_id", addCase},
+	"run":         {"project_id", addRun},
+	"result":      {"test_id", addResult},
+	"shared-step": {"project_id", addSharedStep},
 }
 
 func dispatchAdd(cli client.ClientInterface, cmd *cobra.Command, endpoint string, id int64, args []string, jsonData []byte) error {
@@ -176,7 +176,7 @@ func dispatchAdd(cli client.ClientInterface, cmd *cobra.Command, endpoint string
 		}
 		caseID, err := flags.ValidateRequiredID(args, 2, "case_id")
 		if err != nil {
-			return err
+			return fmt.Errorf("dispatchAdd: %w", err)
 		}
 		return addResultForCase(cli, cmd, id, caseID, jsonData)
 	case "attachment":
@@ -223,6 +223,7 @@ func shouldAutoRunAddInteractive(cmd *cobra.Command, endpoint string, parentID i
 	}
 }
 
+//nolint:gocyclo // Interactive selection flow intentionally keeps explicit back-navigation states.
 func resolveAddParentID(ctx context.Context, p interactive.Prompter, cli client.ClientInterface, endpoint string, currentID int64) (int64, error) {
 	if currentID != 0 || !interactive.HasPrompterInContext(ctx) {
 		return currentID, nil
@@ -852,7 +853,7 @@ func addResultForCase(cli client.ClientInterface, cmd *cobra.Command, runID, cas
 	} else {
 		built, err := buildAddResultReq(cmd, true)
 		if err != nil {
-			return err
+			return fmt.Errorf("addResultForCase: %w", err)
 		}
 		req = *built
 	}
@@ -942,7 +943,7 @@ func runAddAttachment(cli client.ClientInterface, cmd *cobra.Command, args []str
 		}
 		id, err := flags.ValidateRequiredID(args, 2, spec.idLabel)
 		if err != nil {
-			return err
+			return fmt.Errorf("runAddAttachment: %w", err)
 		}
 		return spec.handler(cli, cmd, id, args[3])
 	}
@@ -954,7 +955,7 @@ func runAddAttachment(cli client.ClientInterface, cmd *cobra.Command, args []str
 		}
 		planID, err := flags.ValidateRequiredID(args, 2, "plan_id")
 		if err != nil {
-			return err
+			return fmt.Errorf("runAddAttachment: %w", err)
 		}
 		return addAttachmentToPlanEntry(cli, cmd, planID, args[3], args[4])
 	default:

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -236,43 +236,67 @@ func resolveAddParentID(ctx context.Context, p interactive.Prompter, cli client.
 		}
 		return projectID, nil
 	case "case":
-		projectID, err := interactive.SelectProject(ctx, p, cli, "")
-		if err != nil {
-			return 0, err
-		}
+		var projectID, suiteID int64
+		step := 0 // 0=project, 1=suite, 2=section
+		for {
+			switch step {
+			case 0:
+				var err error
+				projectID, err = interactive.SelectProject(ctx, p, cli, "")
+				if err != nil {
+					return 0, err
+				}
 
-		suites, err := cli.GetSuites(ctx, projectID)
-		if err != nil {
-			return 0, fmt.Errorf("failed to get suites for project %d: %w", projectID, err)
-		}
+				suites, err := cli.GetSuites(ctx, projectID)
+				if err != nil {
+					return 0, fmt.Errorf("failed to get suites for project %d: %w", projectID, err)
+				}
 
-		var suiteID int64
-		switch len(suites) {
-		case 0:
-			suiteID = 0
-		case 1:
-			suiteID = suites[0].ID
-		default:
-			suiteID, err = interactive.SelectSuite(ctx, p, suites, "")
-			if err != nil {
-				return 0, err
+				switch len(suites) {
+				case 0:
+					suiteID = 0
+				case 1:
+					suiteID = suites[0].ID
+				default:
+					step = 1
+					continue
+				}
+				step = 2
+			case 1:
+				suites, err := cli.GetSuites(ctx, projectID)
+				if err != nil {
+					return 0, fmt.Errorf("failed to get suites for project %d: %w", projectID, err)
+				}
+				suiteID, err = interactive.SelectSuite(ctx, p, suites, "", true)
+				if err != nil {
+					if interactive.IsGoBack(err) {
+						step = 0
+						continue
+					}
+					return 0, err
+				}
+				step = 2
+			case 2:
+				sections, err := cli.GetSections(ctx, projectID, suiteID)
+				if err != nil {
+					return 0, fmt.Errorf("failed to get sections for project %d: %w", projectID, err)
+				}
+
+				if len(sections) == 1 {
+					return sections[0].ID, nil
+				}
+
+				sectionID, err := interactive.SelectSection(ctx, p, sections, "", true)
+				if err != nil {
+					if interactive.IsGoBack(err) {
+						step = 1
+						continue
+					}
+					return 0, err
+				}
+				return sectionID, nil
 			}
 		}
-
-		sections, err := cli.GetSections(ctx, projectID, suiteID)
-		if err != nil {
-			return 0, fmt.Errorf("failed to get sections for project %d: %w", projectID, err)
-		}
-
-		if len(sections) == 1 {
-			return sections[0].ID, nil
-		}
-
-		sectionID, err := interactive.SelectSection(ctx, p, sections, "")
-		if err != nil {
-			return 0, err
-		}
-		return sectionID, nil
 	default:
 		return currentID, nil
 	}

--- a/cmd/attachments/add.go
+++ b/cmd/attachments/add.go
@@ -82,7 +82,11 @@ func newAddCaseCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Attachment added (ID: %d)\n   URL: %s", resp.AttachmentID, resp.URL)
-			return output.OutputResult(cmd, resp, "attachments")
+			if err := output.OutputResult(cmd, resp, "attachments"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 	output.AddFlag(cmd)
@@ -147,7 +151,11 @@ func newAddPlanCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Attachment added (ID: %d)\n   URL: %s", resp.AttachmentID, resp.URL)
-			return output.OutputResult(cmd, resp, "attachments")
+			if err := output.OutputResult(cmd, resp, "attachments"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 	output.AddFlag(cmd)
@@ -229,7 +237,11 @@ func newAddPlanEntryCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Attachment added (ID: %d)\n   URL: %s", resp.AttachmentID, resp.URL)
-			return output.OutputResult(cmd, resp, "attachments")
+			if err := output.OutputResult(cmd, resp, "attachments"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 	output.AddFlag(cmd)
@@ -294,7 +306,11 @@ func newAddResultCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Attachment added (ID: %d)\n   URL: %s", resp.AttachmentID, resp.URL)
-			return output.OutputResult(cmd, resp, "attachments")
+			if err := output.OutputResult(cmd, resp, "attachments"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 	output.AddFlag(cmd)
@@ -359,7 +375,11 @@ func newAddRunCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Attachment added (ID: %d)\n   URL: %s", resp.AttachmentID, resp.URL)
-			return output.OutputResult(cmd, resp, "attachments")
+			if err := output.OutputResult(cmd, resp, "attachments"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 	output.AddFlag(cmd)

--- a/cmd/attachments/delete.go
+++ b/cmd/attachments/delete.go
@@ -76,6 +76,7 @@ func newDeleteCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Attachment %d deleted successfully\n", attachmentID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/attachments/interactive_helpers.go
+++ b/cmd/attachments/interactive_helpers.go
@@ -37,22 +37,7 @@ func resolveCaseIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no cases found in suite %d", suiteID)
 	}
 
-	return selectCaseID(ctx, cases)
-}
-
-func selectCaseID(ctx context.Context, cases data.GetCasesResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(cases))
-	for i, kase := range cases {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, kase.ID, kase.Title))
-	}
-
-	idx, _, err := p.Select("Select case:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select case: %w", err)
-	}
-
-	return cases[idx].ID, nil
+	return interactive.SelectCase(ctx, p, cases, "")
 }
 
 func resolveAttachmentIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -69,17 +54,30 @@ func resolveAttachmentIDInteractive(ctx context.Context, cli client.ClientInterf
 		return 0, fmt.Errorf("no attachments found in case %d", caseID)
 	}
 
-	return selectAttachmentID(ctx, attachments)
+	p := interactive.PrompterFromContext(ctx)
+	return selectAttachmentID(ctx, p, attachments)
 }
 
-func selectAttachmentID(ctx context.Context, attachments data.GetAttachmentsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(attachments))
-	for i, a := range attachments {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, a.ID, a.Name))
+func selectAttachmentID(ctx context.Context, p interactive.Prompter, attachments data.GetAttachmentsResponse) (int64, error) {
+	if len(attachments) == 0 {
+		return 0, fmt.Errorf("no attachments found")
 	}
 
-	idx, _, err := p.Select("Select attachment:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(attachments))
+	for i, a := range attachments {
+		rows[i] = []string{fmt.Sprintf("%d", a.ID), a.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select attachment:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select attachment: %w", err)
 	}
@@ -119,22 +117,8 @@ func resolveTestIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no tests found in run %d", runID)
 	}
 
-	return selectTestID(ctx, tests)
-}
-
-func selectTestID(ctx context.Context, tests []data.Test) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(tests))
-	for i, test := range tests {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | case: %d | %s", i+1, test.ID, test.CaseID, test.Title))
-	}
-
-	idx, _, err := p.Select("Select test:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select test: %w", err)
-	}
-
-	return tests[idx].ID, nil
+	return interactive.SelectTest(ctx, p, tests, "")
 }
 
 func resolvePlanIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -152,7 +136,7 @@ func resolvePlanIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no plans found in project %d", projectID)
 	}
 
-	return selectPlanID(ctx, plans)
+	return interactive.SelectPlan(ctx, p, plans, "")
 }
 
 func resolvePlanAndEntryIDInteractive(ctx context.Context, cli client.ClientInterface) (planID int64, entryID string, err error) {
@@ -178,37 +162,8 @@ func resolvePlanEntryIDInteractive(ctx context.Context, cli client.ClientInterfa
 		return "", fmt.Errorf("no plan entries found in plan %d", planID)
 	}
 
-	return selectPlanEntryID(ctx, plan.Entries)
-}
-
-func selectPlanID(ctx context.Context, plans data.GetPlansResponse) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(plans))
-	for i, plan := range plans {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, plan.ID, plan.Name))
-	}
-
-	idx, _, err := p.Select("Select plan:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select plan: %w", err)
-	}
-
-	return plans[idx].ID, nil
-}
-
-func selectPlanEntryID(ctx context.Context, entries []data.PlanEntry) (string, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(entries))
-	for i, entry := range entries {
-		options = append(options, fmt.Sprintf("[%d] ID: %s | %s", i+1, entry.ID, entry.Name))
-	}
-
-	idx, _, err := p.Select("Select plan entry:", options)
-	if err != nil {
-		return "", fmt.Errorf("failed to select plan entry: %w", err)
-	}
-
-	return entries[idx].ID, nil
+	return interactive.SelectPlanEntry(ctx, p, plan.Entries, "")
 }
 
 func resolveResultIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -225,17 +180,31 @@ func resolveResultIDInteractive(ctx context.Context, cli client.ClientInterface)
 		return 0, fmt.Errorf("no results found in test %d", testID)
 	}
 
-	return selectResultID(ctx, results)
+	p := interactive.PrompterFromContext(ctx)
+	return selectResultID(ctx, p, results)
 }
 
-func selectResultID(ctx context.Context, results data.GetResultsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(results))
-	for i, result := range results {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | status: %d | test: %d", i+1, result.ID, result.StatusID, result.TestID))
+func selectResultID(ctx context.Context, p interactive.Prompter, results data.GetResultsResponse) (int64, error) {
+	if len(results) == 0 {
+		return 0, fmt.Errorf("no results found")
 	}
 
-	idx, _, err := p.Select("Select result:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Status", MinWidth: 6},
+		{Header: "Test", MinWidth: 6},
+	}
+	rows := make([][]string, len(results))
+	for i, r := range results {
+		rows[i] = []string{fmt.Sprintf("%d", r.ID), fmt.Sprintf("%d", r.StatusID), fmt.Sprintf("%d", r.TestID)}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select result:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select result: %w", err)
 	}

--- a/cmd/bdds/add.go
+++ b/cmd/bdds/add.go
@@ -76,7 +76,11 @@ Content can be provided via a file or directly.`,
 			}
 
 			ui.Successf(os.Stdout, "BDD added to case %d", caseID)
-			return output.OutputResult(cmd, resp, "bdds")
+			if err := output.OutputResult(cmd, resp, "bdds"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/bdds/interactive_helpers.go
+++ b/cmd/bdds/interactive_helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 )
 
 func resolveCaseIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -30,20 +29,5 @@ func resolveCaseIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no cases found in project %d suite %d", projectID, suiteID)
 	}
 
-	return selectCaseID(ctx, cases)
-}
-
-func selectCaseID(ctx context.Context, cases data.GetCasesResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(cases))
-	for i, c := range cases {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, c.ID, c.Title))
-	}
-
-	idx, _, err := p.Select("Select case:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select case: %w", err)
-	}
-
-	return cases[idx].ID, nil
+	return interactive.SelectCase(ctx, p, cases, "")
 }

--- a/cmd/cases/add.go
+++ b/cmd/cases/add.go
@@ -104,7 +104,11 @@ func newAddCmd(getClient GetClientFunc) *cobra.Command {
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Case created (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "cases")
+			if err := output.OutputResult(cmd, resp, "cases"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/cases/bulk.go
+++ b/cmd/cases/bulk.go
@@ -105,7 +105,11 @@ func newBulkUpdateCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Updated %d cases", len(caseIDs))
-			return output.OutputResult(cmd, resp, "cases")
+			if err := output.OutputResult(cmd, resp, "cases"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(cmd.Context(), cmd)
+			return nil
 		},
 	}
 
@@ -174,6 +178,7 @@ func newBulkDeleteCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Deleted %d cases", len(caseIDs))
+			interactive.MutationPostAction(cmd.Context(), cmd)
 			return nil
 		},
 	}
@@ -240,6 +245,7 @@ func newBulkCopyCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Copied %d cases to section %d", len(caseIDs), sectionID)
+			interactive.MutationPostAction(cmd.Context(), cmd)
 			return nil
 		},
 	}
@@ -306,6 +312,7 @@ func newBulkMoveCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Moved %d cases to section %d", len(caseIDs), sectionID)
+			interactive.MutationPostAction(cmd.Context(), cmd)
 			return nil
 		},
 	}

--- a/cmd/cases/delete.go
+++ b/cmd/cases/delete.go
@@ -78,6 +78,7 @@ func newDeleteCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Case %d deleted", caseID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/cases/interactive_helpers.go
+++ b/cmd/cases/interactive_helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 )
 
 func resolveCaseIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -37,22 +36,7 @@ func resolveCaseIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no cases found in suite %d", suiteID)
 	}
 
-	return selectCaseID(ctx, cases)
-}
-
-func selectCaseID(ctx context.Context, cases data.GetCasesResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(cases))
-	for i, kase := range cases {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, kase.ID, kase.Title))
-	}
-
-	idx, _, err := p.Select("Select case:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select case: %w", err)
-	}
-
-	return cases[idx].ID, nil
+	return interactive.SelectCase(ctx, p, cases, "")
 }
 
 func resolveSectionIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -69,7 +53,8 @@ func resolveSectionIDInteractive(ctx context.Context, cli client.ClientInterface
 		return 0, fmt.Errorf("no sections found in suite %d", suiteID)
 	}
 
-	return selectSectionID(ctx, sections)
+	p := interactive.PrompterFromContext(ctx)
+	return interactive.SelectSection(ctx, p, sections, "")
 }
 
 func resolveSuiteIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -101,19 +86,4 @@ func resolveProjectAndSuiteInteractive(ctx context.Context, cli client.ClientInt
 	}
 
 	return projectID, suiteID, nil
-}
-
-func selectSectionID(ctx context.Context, sections data.GetSectionsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(sections))
-	for i, section := range sections {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, section.ID, section.Name))
-	}
-
-	idx, _, err := p.Select("Select section:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select section: %w", err)
-	}
-
-	return sections[idx].ID, nil
 }

--- a/cmd/cases/interactive_helpers_test.go
+++ b/cmd/cases/interactive_helpers_test.go
@@ -123,16 +123,6 @@ func TestResolveCaseIDInteractive_Success(t *testing.T) {
 	assert.Equal(t, int64(200), id)
 }
 
-func TestSelectCaseID_NonInteractive(t *testing.T) {
-	ctx := interactive.WithPrompter(context.Background(), interactive.NewNonInteractivePrompter())
-	cases := data.GetCasesResponse{{ID: 100, Title: "Case A"}}
-
-	id, err := selectCaseID(ctx, cases)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to select case")
-	assert.Zero(t, id)
-}
-
 // ============= LAYER 2: SelectProject and SelectSuite error paths =============
 
 func TestResolveCaseIDInteractive_SelectProjectError(t *testing.T) {

--- a/cmd/cases/update.go
+++ b/cmd/cases/update.go
@@ -107,7 +107,11 @@ func newUpdateCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Case %d updated", caseID)
-			return output.OutputResult(cmd, resp, "cases")
+			if err := output.OutputResult(cmd, resp, "cases"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/compare/all.go
+++ b/cmd/compare/all.go
@@ -519,22 +519,41 @@ func parseCommonFlags(cmd *cobra.Command, cli client.ClientInterface) (pid1, pid
 
 	pid1Str, _ := cmd.Flags().GetString("pid1")
 	pid1, _ = flags.ParseID(pid1Str)
-	if pid1 <= 0 {
-		pid1, err = interactive.SelectProject(ctx, p, cli, "Select first project (pid1):")
-		if err != nil {
-			return 0, 0, "", "", fmt.Errorf("pid1 not specified and interactive selection failed: %w", err)
-		}
-		usedInteractivePID = true
-	}
 
 	pid2Str, _ := cmd.Flags().GetString("pid2")
 	pid2, _ = flags.ParseID(pid2Str)
-	if pid2 <= 0 {
-		pid2, err = interactive.SelectProject(ctx, p, cli, "Select second project (pid2):")
-		if err != nil {
-			return 0, 0, "", "", fmt.Errorf("pid2 not specified and interactive selection failed: %w", err)
+
+	// Interactive project selection with back-navigation loop.
+	if pid1 <= 0 || pid2 <= 0 {
+	selectLoop:
+		for {
+			if pid1 <= 0 {
+				pid1, err = interactive.SelectProject(ctx, p, cli, "Select first project (pid1):")
+				if err != nil {
+					if interactive.IsGoBack(err) || interactive.IsExit(err) {
+						return 0, 0, "", "", err
+					}
+					return 0, 0, "", "", fmt.Errorf("pid1 not specified and interactive selection failed: %w", err)
+				}
+				usedInteractivePID = true
+			}
+
+			if pid2 <= 0 {
+				pid2, err = interactive.SelectProject(ctx, p, cli, "Select second project (pid2):", true)
+				if err != nil {
+					if interactive.IsExit(err) {
+						return 0, 0, "", "", err
+					}
+					if interactive.IsGoBack(err) {
+						pid1 = 0
+						continue selectLoop
+					}
+					return 0, 0, "", "", fmt.Errorf("pid2 not specified and interactive selection failed: %w", err)
+				}
+				usedInteractivePID = true
+			}
+			break
 		}
-		usedInteractivePID = true
 	}
 
 	format, _ = cmd.Flags().GetString("format")

--- a/cmd/compare/all.go
+++ b/cmd/compare/all.go
@@ -109,16 +109,16 @@ func newSimpleResourceEntry(displayName, key, label string, field func(*allResul
 }
 
 var (
-	compareAllPipe      = os.Pipe
-	compareAllCopy      = io.Copy
-	compareAllWriteFile = os.WriteFile
-	compareAllCasesFn   = compareCasesInternal
-	compareAllSuitesFn  = compareSuitesInternalWithSuites
+	compareAllPipe       = os.Pipe
+	compareAllCopy       = io.Copy
+	compareAllWriteFile  = os.WriteFile
+	compareAllCasesFn    = compareCasesInternal
+	compareAllSuitesFn   = compareSuitesInternalWithSuites
 	compareAllSectionsFn = compareSectionsInternalWithSuites
-	compareAllSimpleFn  = compareSimpleInternal
-	resolveSavePathFn   = outpututils.ResolveSavePathFromFlags
-	promptSavePathFn    = outpututils.PromptSavePath
-	saveAllResultFn     = saveAllResult
+	compareAllSimpleFn   = compareSimpleInternal
+	resolveSavePathFn    = outpututils.ResolveSavePathFromFlags
+	promptSavePathFn     = outpututils.PromptSavePath
+	saveAllResultFn      = saveAllResult
 )
 
 func printCompareAllStageProgress(w io.Writer, current string) {
@@ -381,12 +381,12 @@ func executeCompareAll(cmd *cobra.Command, _ []string) error {
 
 	pid1, pid2, format, savePath, err := parseCommonFlags(cmd, cli)
 	if err != nil {
-		return err
+		return fmt.Errorf("executeCompareAll: %w", err)
 	}
 
 	project1Name, project2Name, err := GetProjectNames(ctx, cli, pid1, pid2)
 	if err != nil {
-		return err
+		return fmt.Errorf("executeCompareAll: %w", err)
 	}
 
 	startTime := time.Now()
@@ -489,7 +489,7 @@ func saveCompareAllOutput(cmd *cobra.Command, result *allResult, format, savePat
 	switch format {
 	case "json", "yaml":
 		if err := saveAllResultFn(result, format, savePath); err != nil {
-			return err
+			return fmt.Errorf("saveCompareAllOutput: %w", err)
 		}
 		if !quiet {
 			fmt.Println()
@@ -512,6 +512,7 @@ var allCmd = newAllCmd()
 //   - "__DEFAULT__" if --save flag was used (save to default location)
 //   - custom path if --save-to flag was used
 //   - "" if neither flag was used
+//nolint:gocyclo // Interactive flag parsing with back-navigation is intentionally explicit.
 func parseCommonFlags(cmd *cobra.Command, cli client.ClientInterface) (pid1, pid2 int64, format, savePath string, err error) {
 	ctx := cmd.Context()
 	p := interactive.PrompterFromContext(ctx)
@@ -525,7 +526,6 @@ func parseCommonFlags(cmd *cobra.Command, cli client.ClientInterface) (pid1, pid
 
 	// Interactive project selection with back-navigation loop.
 	if pid1 <= 0 || pid2 <= 0 {
-	selectLoop:
 		for {
 			if pid1 <= 0 {
 				pid1, err = interactive.SelectProject(ctx, p, cli, "Select first project (pid1):")
@@ -546,7 +546,7 @@ func parseCommonFlags(cmd *cobra.Command, cli client.ClientInterface) (pid1, pid
 					}
 					if interactive.IsGoBack(err) {
 						pid1 = 0
-						continue selectLoop
+						continue
 					}
 					return 0, 0, "", "", fmt.Errorf("pid2 not specified and interactive selection failed: %w", err)
 				}

--- a/cmd/compare/all.go
+++ b/cmd/compare/all.go
@@ -406,6 +406,15 @@ func executeCompareAll(cmd *cobra.Command, _ []string) error {
 	if savePath != "" {
 		return saveCompareAllOutput(cmd, result, format, savePath, quiet, project1Name, pid1, project2Name, pid2, errs, elapsed)
 	}
+
+	// Post-action menu with drill-down (interactive only, non-save).
+	if !quiet {
+		action := compareAllPostAction(ctx, cmd, result, project1Name, project2Name, pid1, pid2)
+		if action == actionSave {
+			return saveCompareAllOutput(cmd, result, format, "__DEFAULT__", quiet, project1Name, pid1, project2Name, pid2, errs, elapsed)
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/compare/cases.go
+++ b/cmd/compare/cases.go
@@ -143,6 +143,11 @@ Examples:
 				)
 			}
 
+			// Post-action menu (interactive only, non-save).
+			if savePath == "" && !quiet {
+				comparePostAction(ctx, cmd, *result, project1Name, project2Name)
+			}
+
 			return nil
 		},
 	}

--- a/cmd/compare/cases.go
+++ b/cmd/compare/cases.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/concurrency"
 	"github.com/Korrnals/gotr/internal/debug"
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/models/data"
 	outpututils "github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/ui"
@@ -124,13 +125,21 @@ Examples:
 
 			elapsed := time.Since(startTime)
 
-			// Print or save result
-			if err := PrintCompareResult(cmd, *result, project1Name, project2Name, format, savePath); err != nil {
-				return err
+			quiet, _ := cmd.Flags().GetBool("quiet")
+
+			// In interactive mode with table format and no save — skip
+			// dumping the giant table to stdout. The user can view it
+			// through "📋 View detailed results" in the post-action menu.
+			isInteractiveTable := format == "table" && savePath == "" && !quiet &&
+				interactive.HasPrompterInContext(ctx) && !interactive.IsNonInteractive(ctx)
+
+			if !isInteractiveTable {
+				if err := PrintCompareResult(cmd, *result, project1Name, project2Name, format, savePath); err != nil {
+					return err
+				}
 			}
 
 			// Print statistics
-			quiet, _ := cmd.Flags().GetBool("quiet")
 			if !quiet {
 				PrintCasesStatsWithErrors(
 					pid1,

--- a/cmd/compare/interactive_helpers.go
+++ b/cmd/compare/interactive_helpers.go
@@ -76,7 +76,9 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 		runSyncFromCompare(ctx, cmd, result)
 		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	case actionSnap:
-		runSnapFromPostAction(ctx, cmd)
+		if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
+			ui.Error(os.Stdout, err.Error())
+		}
 		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	default:
 		return key
@@ -207,15 +209,6 @@ func runSyncFromCompare(ctx context.Context, compareCmd *cobra.Command, result C
 	fmt.Println()
 }
 
-// runSnapFromPostAction launches the snap list command from a post-action menu.
-func runSnapFromPostAction(ctx context.Context, cmd *cobra.Command) {
-	fmt.Println()
-	if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
-		ui.Error(os.Stdout, err.Error())
-	}
-	fmt.Println()
-}
-
 // compareAllPostAction shows a post-action menu for compare-all with drill-down.
 // resources maps resource display names to their CompareResult.
 func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allResult, p1Name, p2Name string, pid1, pid2 int64) string {
@@ -249,7 +242,9 @@ func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allRe
 		// Save is handled by caller (save flags).
 		return actionSave
 	case actionSnap:
-		runSnapFromPostAction(ctx, cmd)
+		if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
+			ui.Error(os.Stdout, err.Error())
+		}
 		return compareAllPostAction(ctx, cmd, result, p1Name, p2Name, pid1, pid2)
 	default:
 		return key

--- a/cmd/compare/interactive_helpers.go
+++ b/cmd/compare/interactive_helpers.go
@@ -328,14 +328,14 @@ func promptAndSave(ctx context.Context, p interactive.Prompter, cmd *cobra.Comma
 	formats := []string{"json", "yaml", "csv", "table (text)"}
 	idx, _, err := p.Select("Save format:", formats)
 	if err != nil {
-		return err
+		return fmt.Errorf("promptAndSave: %w", err)
 	}
 
 	format := []string{"json", "yaml", "csv", "table"}[idx]
 
 	input, err := p.Input("File path (or empty for default):", "")
 	if err != nil {
-		return err
+		return fmt.Errorf("promptAndSave: %w", err)
 	}
 	savePath := strings.TrimSpace(input)
 
@@ -351,7 +351,7 @@ func promptAndSave(ctx context.Context, p interactive.Prompter, cmd *cobra.Comma
 	}
 
 	if err := PrintCompareResult(cmd, result, p1Name, p2Name, format, savePath); err != nil {
-		return err
+		return fmt.Errorf("promptAndSave: %w", err)
 	}
 
 	return nil
@@ -374,12 +374,12 @@ func renderTableLines(result CompareResult, p1Name, p2Name string) []string {
 // --- Line rendering helpers (mirror the existing print* functions but return []string) ---
 
 func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName string) []string {
-	numWidth := 5  // row number "#"
-	idWidth := 8   // TestRail ID
+	numWidth := 5 // row number "#"
+	idWidth := 8  // TestRail ID
 	// Adaptive name width: fill remaining terminal space.
 	// Layout: │ # │ ID │ Name │  →  1 + (numW+2) + 1 + (idW+2) + 1 + (nameW+2) + 1
 	termW := interactive.TerminalWidth()
-	nameWidth := termW - numWidth - idWidth - 10 // 10 = borders + padding
+	nameWidth := termW - numWidth - idWidth - 10
 	if nameWidth < 30 {
 		nameWidth = 30
 	}
@@ -393,20 +393,26 @@ func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName str
 
 	title := fmt.Sprintf("Only in project %d — %q (%d items)", projectID, projectName, len(items))
 	var lines []string
-	lines = append(lines, hBorder("┌", "┬", "┐", widths))
-	lines = append(lines, headerLine(title, totalInnerWidth))
+	lines = append(lines,
+		hBorder("┌", "┬", "┐", widths),
+		headerLine(title, totalInnerWidth),
+	)
 
 	if len(items) == 0 {
-		lines = append(lines, separatorLine(widths))
-		lines = append(lines, headerLine("(none)", totalInnerWidth))
-		lines = append(lines, hBorder("└", "┴", "┘", widths))
-		lines = append(lines, "")
+		lines = append(lines,
+			separatorLine(widths),
+			headerLine("(none)", totalInnerWidth),
+			hBorder("└", "┴", "┘", widths),
+			"",
+		)
 		return lines
 	}
 
-	lines = append(lines, separatorLine(widths))
-	lines = append(lines, rowLine([]string{"#", "ID", "Name"}, widths))
-	lines = append(lines, separatorLine(widths))
+	lines = append(lines,
+		separatorLine(widths),
+		rowLine([]string{"#", "ID", "Name"}, widths),
+		separatorLine(widths),
+	)
 
 	for i, item := range items {
 		lines = append(lines, rowLine([]string{
@@ -416,8 +422,10 @@ func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName str
 		}, widths))
 	}
 
-	lines = append(lines, hBorder("└", "┴", "┘", widths))
-	lines = append(lines, "")
+	lines = append(lines,
+		hBorder("└", "┴", "┘", widths),
+		"",
+	)
 	return lines
 }
 
@@ -443,26 +451,32 @@ func renderCommonLines(items []CommonItemInfo, pid1, pid2 int64) []string {
 
 	title := fmt.Sprintf("Common in both projects (%d items)", len(items))
 	var lines []string
-	lines = append(lines, hBorder("┌", "┬", "┐", widths))
-	lines = append(lines, headerLine(title, totalInnerWidth))
+	lines = append(lines,
+		hBorder("┌", "┬", "┐", widths),
+		headerLine(title, totalInnerWidth),
+	)
 
 	if len(items) == 0 {
-		lines = append(lines, separatorLine(widths))
-		lines = append(lines, headerLine("(none)", totalInnerWidth))
-		lines = append(lines, hBorder("└", "┴", "┘", widths))
-		lines = append(lines, "")
+		lines = append(lines,
+			separatorLine(widths),
+			headerLine("(none)", totalInnerWidth),
+			hBorder("└", "┴", "┘", widths),
+			"",
+		)
 		return lines
 	}
 
-	lines = append(lines, separatorLine(widths))
-	lines = append(lines, rowLine([]string{
+	lines = append(lines,
+		separatorLine(widths),
+		rowLine([]string{
 		"#",
 		"Name",
 		fmt.Sprintf("ID P%d", pid1),
 		fmt.Sprintf("ID P%d", pid2),
 		"Status",
-	}, widths))
-	lines = append(lines, separatorLine(widths))
+		}, widths),
+		separatorLine(widths),
+	)
 
 	for i, item := range items {
 		status := "✓ Match"
@@ -478,8 +492,10 @@ func renderCommonLines(items []CommonItemInfo, pid1, pid2 int64) []string {
 		}, widths))
 	}
 
-	lines = append(lines, hBorder("└", "┴", "┘", widths))
-	lines = append(lines, "")
+	lines = append(lines,
+		hBorder("└", "┴", "┘", widths),
+		"",
+	)
 	return lines
 }
 
@@ -508,20 +524,26 @@ func renderIDMappingLines(items []CommonItemInfo) []string {
 
 	title := fmt.Sprintf("ID mapping — for updates (%d items)", len(mappings))
 	var lines []string
-	lines = append(lines, hBorder("┌", "┬", "┐", widths))
-	lines = append(lines, headerLine(title, totalInnerWidth))
+	lines = append(lines,
+		hBorder("┌", "┬", "┐", widths),
+		headerLine(title, totalInnerWidth),
+	)
 
 	if len(mappings) == 0 {
-		lines = append(lines, separatorLine(widths))
-		lines = append(lines, headerLine("(all IDs match)", totalInnerWidth))
-		lines = append(lines, hBorder("└", "┴", "┘", widths))
-		lines = append(lines, "")
+		lines = append(lines,
+			separatorLine(widths),
+			headerLine("(all IDs match)", totalInnerWidth),
+			hBorder("└", "┴", "┘", widths),
+			"",
+		)
 		return lines
 	}
 
-	lines = append(lines, separatorLine(widths))
-	lines = append(lines, rowLine([]string{"#", "Source ID", "Target ID", "Name"}, widths))
-	lines = append(lines, separatorLine(widths))
+	lines = append(lines,
+		separatorLine(widths),
+		rowLine([]string{"#", "Source ID", "Target ID", "Name"}, widths),
+		separatorLine(widths),
+	)
 
 	for i, item := range mappings {
 		lines = append(lines, rowLine([]string{
@@ -532,8 +554,10 @@ func renderIDMappingLines(items []CommonItemInfo) []string {
 		}, widths))
 	}
 
-	lines = append(lines, hBorder("└", "┴", "┘", widths))
-	lines = append(lines, "")
+	lines = append(lines,
+		hBorder("└", "┴", "┘", widths),
+		"",
+	)
 	return lines
 }
 

--- a/cmd/compare/interactive_helpers.go
+++ b/cmd/compare/interactive_helpers.go
@@ -1,0 +1,361 @@
+package compare
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Korrnals/gotr/internal/interactive"
+	"github.com/Korrnals/gotr/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// Post-action option keys.
+const (
+	actionExit     = "exit"
+	actionBack     = "back"
+	actionSave     = "save"
+	actionSync     = "sync"
+	actionSnap     = "snap"
+	actionDrillRes = "drill_resource"
+)
+
+// comparePostAction shows a post-action menu after a compare result.
+// It loops until the user exits or chooses back (for re-compare).
+// Returns the selected action key. Non-interactive → returns immediately.
+func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareResult, p1Name, p2Name string) string {
+	if !interactive.HasPrompterInContext(ctx) || interactive.IsNonInteractive(ctx) {
+		return actionExit
+	}
+	p := interactive.PrompterFromContext(ctx)
+
+	hasDifferences := len(result.OnlyInFirst) > 0 || len(result.OnlyInSecond) > 0
+
+	options := []interactive.ActionOption{
+		{Label: interactive.OptExit, Key: actionExit},
+		{Label: "💾 Save results to file", Key: actionSave},
+		{Label: "→ Sync: migrate differences", Key: actionSync, Disabled: !hasDifferences, Hint: "no differences found"},
+	}
+
+	key, err := interactive.ActionMenu(ctx, p, "Comparison complete. What next?", options)
+	if err != nil {
+		return actionExit
+	}
+
+	switch key {
+	case actionSave:
+		if err := promptAndSave(ctx, p, cmd, result, p1Name, p2Name); err != nil {
+			ui.Error(os.Stdout, fmt.Sprintf("Save failed: %v", err))
+		}
+		// After save, show menu again.
+		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
+	default:
+		return key
+	}
+}
+
+// compareAllPostAction shows a post-action menu for compare-all with drill-down.
+// resources maps resource display names to their CompareResult.
+func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allResult, p1Name, p2Name string, pid1, pid2 int64) string {
+	if !interactive.HasPrompterInContext(ctx) || interactive.IsNonInteractive(ctx) {
+		return actionExit
+	}
+	p := interactive.PrompterFromContext(ctx)
+
+	options := []interactive.ActionOption{
+		{Label: interactive.OptExit, Key: actionExit},
+		{Label: "🔍 Drill-down: view resource details", Key: actionDrillRes},
+		{Label: "💾 Save results to file", Key: actionSave},
+	}
+
+	key, err := interactive.ActionMenu(ctx, p, "Compare all complete. What next?", options)
+	if err != nil {
+		return actionExit
+	}
+
+	switch key {
+	case actionDrillRes:
+		drillDownResource(ctx, p, result, p1Name, p2Name)
+		return compareAllPostAction(ctx, cmd, result, p1Name, p2Name, pid1, pid2)
+	case actionSave:
+		// Save is handled by caller (save flags).
+		return actionSave
+	default:
+		return key
+	}
+}
+
+// drillDownResource lets the user pick a resource and view its detailed table (paged).
+func drillDownResource(ctx context.Context, p interactive.Prompter, result *allResult, p1Name, p2Name string) {
+	resources := collectDrillDownResources(result)
+	if len(resources) == 0 {
+		ui.Infof(os.Stdout, "No resource data available for drill-down.")
+		return
+	}
+
+	labels := make([]string, len(resources))
+	for i, r := range resources {
+		labels[i] = fmt.Sprintf("%-16s  P1: %d unique │ P2: %d unique │ Common: %d",
+			r.name,
+			len(r.result.OnlyInFirst),
+			len(r.result.OnlyInSecond),
+			len(r.result.Common))
+	}
+
+	for {
+		idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+			Prompt:    "Select resource to view details:",
+			Items:     labels,
+			AllowBack: true,
+		})
+		if err != nil {
+			return // back or exit
+		}
+
+		r := resources[idx]
+		lines := renderTableLines(r.result, p1Name, p2Name)
+		if interactive.ShouldPage(len(lines)) {
+			_ = interactive.Pager(interactive.PagerConfig{
+				Lines:  lines,
+				Header: fmt.Sprintf("=== %s (projects %d ↔ %d) ===", r.result.Resource, r.result.Project1ID, r.result.Project2ID),
+			})
+		} else {
+			for _, line := range lines {
+				fmt.Println(line)
+			}
+		}
+	}
+}
+
+type drillDownEntry struct {
+	name   string
+	result CompareResult
+}
+
+func collectDrillDownResources(result *allResult) []drillDownEntry {
+	type named struct {
+		name string
+		ptr  *CompareResult
+	}
+	all := []named{
+		{"Cases", result.Cases},
+		{"Suites", result.Suites},
+		{"Sections", result.Sections},
+		{"Shared Steps", result.SharedSteps},
+		{"Runs", result.Runs},
+		{"Plans", result.Plans},
+		{"Milestones", result.Milestones},
+		{"Datasets", result.Datasets},
+		{"Groups", result.Groups},
+		{"Labels", result.Labels},
+		{"Templates", result.Templates},
+		{"Configurations", result.Configurations},
+	}
+
+	entries := make([]drillDownEntry, 0, len(all))
+	for _, r := range all {
+		if r.ptr != nil && r.ptr.Status == CompareStatusComplete {
+			entries = append(entries, drillDownEntry{name: r.name, result: *r.ptr})
+		}
+	}
+	return entries
+}
+
+// promptAndSave prompts the user for format and saves the result.
+func promptAndSave(ctx context.Context, p interactive.Prompter, cmd *cobra.Command, result CompareResult, p1Name, p2Name string) error {
+	formats := []string{"json", "yaml", "csv", "table (text)"}
+	idx, _, err := p.Select("Save format:", formats)
+	if err != nil {
+		return err
+	}
+
+	format := []string{"json", "yaml", "csv", "table"}[idx]
+
+	input, err := p.Input("File path (or empty for default):", "")
+	if err != nil {
+		return err
+	}
+	savePath := strings.TrimSpace(input)
+	if savePath == "" {
+		savePath = "__DEFAULT__"
+	}
+
+	return PrintCompareResult(cmd, result, p1Name, p2Name, format, savePath)
+}
+
+// renderTableLines builds the compare table as a slice of strings (one per line)
+// suitable for paging or saving. Does not print to stdout.
+func renderTableLines(result CompareResult, p1Name, p2Name string) []string {
+	var lines []string
+
+	lines = append(lines, fmt.Sprintf("\n=== Comparison: %s (projects %d ↔ %d) ===\n", result.Resource, result.Project1ID, result.Project2ID))
+	lines = append(lines, renderOnlyInProjectLines(result.OnlyInFirst, result.Project1ID, p1Name)...)
+	lines = append(lines, renderOnlyInProjectLines(result.OnlyInSecond, result.Project2ID, p2Name)...)
+	lines = append(lines, renderCommonLines(result.Common, result.Project1ID, result.Project2ID)...)
+	lines = append(lines, renderIDMappingLines(result.Common)...)
+
+	return lines
+}
+
+// --- Line rendering helpers (mirror the existing print* functions but return []string) ---
+
+func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName string) []string {
+	idWidth := 8
+	nameWidth := 70
+	widths := []int{idWidth, nameWidth}
+	totalInnerWidth := idWidth + nameWidth + 3*len(widths) - 1
+
+	title := fmt.Sprintf("Only in project %d - %q", projectID, projectName)
+	var lines []string
+	lines = append(lines, hBorder("┌", "┬", "┐", widths))
+	lines = append(lines, headerLine(title, totalInnerWidth))
+
+	if len(items) == 0 {
+		lines = append(lines, separatorLine(widths))
+		lines = append(lines, headerLine("(none)", totalInnerWidth))
+		lines = append(lines, hBorder("└", "┴", "┘", widths))
+		lines = append(lines, "")
+		return lines
+	}
+
+	lines = append(lines, separatorLine(widths))
+	lines = append(lines, rowLine([]string{"ID", "Name"}, widths))
+	lines = append(lines, separatorLine(widths))
+
+	for _, item := range items {
+		lines = append(lines, rowLine([]string{fmt.Sprintf("%d", item.ID), item.Name}, widths))
+	}
+
+	lines = append(lines, hBorder("└", "┴", "┘", widths))
+	lines = append(lines, "")
+	return lines
+}
+
+func renderCommonLines(items []CommonItemInfo, pid1, pid2 int64) []string {
+	nameWidth := 50
+	id1Width := 12
+	id2Width := 12
+	statusWidth := 20
+	widths := []int{nameWidth, id1Width, id2Width, statusWidth}
+	totalInnerWidth := nameWidth + id1Width + id2Width + statusWidth + 3*len(widths) - 1
+
+	var lines []string
+	lines = append(lines, hBorder("┌", "┬", "┐", widths))
+	lines = append(lines, headerLine("Common in both projects", totalInnerWidth))
+
+	if len(items) == 0 {
+		lines = append(lines, separatorLine(widths))
+		lines = append(lines, headerLine("(none)", totalInnerWidth))
+		lines = append(lines, hBorder("└", "┴", "┘", widths))
+		lines = append(lines, "")
+		return lines
+	}
+
+	lines = append(lines, separatorLine(widths))
+	lines = append(lines, rowLine([]string{
+		"Name",
+		fmt.Sprintf("ID proj %d", pid1),
+		fmt.Sprintf("ID proj %d", pid2),
+		"ID status",
+	}, widths))
+	lines = append(lines, separatorLine(widths))
+
+	for _, item := range items {
+		status := "✓ Match"
+		if !item.IDsMatch {
+			status = "⚠ Differ"
+		}
+		lines = append(lines, rowLine([]string{
+			item.Name,
+			fmt.Sprintf("%d", item.ID1),
+			fmt.Sprintf("%d", item.ID2),
+			status,
+		}, widths))
+	}
+
+	lines = append(lines, hBorder("└", "┴", "┘", widths))
+	lines = append(lines, "")
+	return lines
+}
+
+func renderIDMappingLines(items []CommonItemInfo) []string {
+	var mappings []CommonItemInfo
+	for _, item := range items {
+		if !item.IDsMatch {
+			mappings = append(mappings, item)
+		}
+	}
+
+	sourceWidth := 12
+	targetWidth := 12
+	nameWidth := 70
+	widths := []int{sourceWidth, targetWidth, nameWidth}
+	totalInnerWidth := sourceWidth + targetWidth + nameWidth + 3*len(widths) - 1
+
+	var lines []string
+	lines = append(lines, hBorder("┌", "┬", "┐", widths))
+	lines = append(lines, headerLine("ID mapping (for updates)", totalInnerWidth))
+
+	if len(mappings) == 0 {
+		lines = append(lines, separatorLine(widths))
+		lines = append(lines, headerLine("(all IDs match)", totalInnerWidth))
+		lines = append(lines, hBorder("└", "┴", "┘", widths))
+		lines = append(lines, "")
+		return lines
+	}
+
+	lines = append(lines, separatorLine(widths))
+	lines = append(lines, rowLine([]string{"Source ID", "Target ID", "Name"}, widths))
+	lines = append(lines, separatorLine(widths))
+
+	for _, item := range mappings {
+		lines = append(lines, rowLine([]string{
+			fmt.Sprintf("%d", item.ID1),
+			fmt.Sprintf("%d", item.ID2),
+			item.Name,
+		}, widths))
+	}
+
+	lines = append(lines, hBorder("└", "┴", "┘", widths))
+	lines = append(lines, "")
+	return lines
+}
+
+// --- String-based table rendering helpers ---
+
+func hBorder(left, mid, right string, widths []int) string {
+	parts := make([]string, len(widths))
+	for i, w := range widths {
+		parts[i] = strings.Repeat("─", w+2)
+	}
+	return left + strings.Join(parts, mid) + right
+}
+
+func headerLine(title string, totalWidth int) string {
+	titleWidth := len([]rune(title))
+	padding := totalWidth - 2 - titleWidth
+	if padding < 0 {
+		padding = 0
+		title = truncateString(title, totalWidth-2)
+	}
+	leftPad := padding / 2
+	rightPad := padding - leftPad
+	return "│" + strings.Repeat(" ", leftPad) + title + strings.Repeat(" ", rightPad) + "│"
+}
+
+func separatorLine(widths []int) string {
+	parts := make([]string, len(widths))
+	for i, w := range widths {
+		parts[i] = strings.Repeat("─", w+2)
+	}
+	return "├" + strings.Join(parts, "┼") + "┤"
+}
+
+func rowLine(cells []string, widths []int) string {
+	parts := make([]string, len(cells))
+	for i, cell := range cells {
+		parts[i] = " " + padRight(truncateString(cell, widths[i]), widths[i]) + " "
+	}
+	return "│" + strings.Join(parts, "│") + "│"
+}

--- a/cmd/compare/interactive_helpers.go
+++ b/cmd/compare/interactive_helpers.go
@@ -18,7 +18,6 @@ const (
 	actionBack     = "back"
 	actionSave     = "save"
 	actionSync     = "sync"
-	actionSnap     = "snap"
 	actionDrillRes = "drill_resource"
 )
 
@@ -44,8 +43,8 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 		{Label: "📋 View detailed results", Key: actionDrillRes, Disabled: !hasData, Hint: "no data"},
 		{Label: "💾 Save results to file", Key: actionSave},
 		{Label: "→ Sync: migrate differences", Key: actionSync, Disabled: !hasDifferences, Hint: "no differences found"},
-		{Label: "📦 Snap: manage snapshots", Key: actionSnap},
 	}
+	options = append(options, interactive.CrossNavOptions()...)
 
 	key, err := interactive.ActionMenu(ctx, p, "Comparison complete. What next?", options)
 	if err != nil {
@@ -75,12 +74,11 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 	case actionSync:
 		runSyncFromCompare(ctx, cmd, result)
 		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
-	case actionSnap:
-		if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
-			ui.Error(os.Stdout, err.Error())
-		}
-		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	default:
+		// Cross-navigation keys (nav:compare, nav:sync, nav:snap).
+		if interactive.HandleCrossNav(ctx, cmd, key) {
+			return comparePostAction(ctx, cmd, result, p1Name, p2Name)
+		}
 		return key
 	}
 }
@@ -226,8 +224,8 @@ func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allRe
 		{Label: interactive.OptExit, Key: actionExit},
 		{Label: "🔍 Drill-down: view resource details", Key: actionDrillRes},
 		{Label: "💾 Save results to file", Key: actionSave},
-		{Label: "📦 Snap: manage snapshots", Key: actionSnap},
 	}
+	options = append(options, interactive.CrossNavOptions()...)
 
 	key, err := interactive.ActionMenu(ctx, p, "Compare all complete. What next?", options)
 	if err != nil {
@@ -241,12 +239,10 @@ func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allRe
 	case actionSave:
 		// Save is handled by caller (save flags).
 		return actionSave
-	case actionSnap:
-		if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
-			ui.Error(os.Stdout, err.Error())
-		}
-		return compareAllPostAction(ctx, cmd, result, p1Name, p2Name, pid1, pid2)
 	default:
+		if interactive.HandleCrossNav(ctx, cmd, key) {
+			return compareAllPostAction(ctx, cmd, result, p1Name, p2Name, pid1, pid2)
+		}
 		return key
 	}
 }

--- a/cmd/compare/interactive_helpers.go
+++ b/cmd/compare/interactive_helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Korrnals/gotr/internal/interactive"
+	outpututils "github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -31,9 +32,11 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 	p := interactive.PrompterFromContext(ctx)
 
 	hasDifferences := len(result.OnlyInFirst) > 0 || len(result.OnlyInSecond) > 0
+	hasData := hasDifferences || len(result.Common) > 0
 
 	options := []interactive.ActionOption{
 		{Label: interactive.OptExit, Key: actionExit},
+		{Label: "📋 View detailed results", Key: actionDrillRes, Disabled: !hasData, Hint: "no data"},
 		{Label: "💾 Save results to file", Key: actionSave},
 		{Label: "→ Sync: migrate differences", Key: actionSync, Disabled: !hasDifferences, Hint: "no differences found"},
 	}
@@ -44,15 +47,150 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 	}
 
 	switch key {
+	case actionDrillRes:
+		lines := renderTableLines(result, p1Name, p2Name)
+		if interactive.ShouldPage(len(lines)) {
+			_ = interactive.Pager(interactive.PagerConfig{
+				Lines:  lines,
+				Header: fmt.Sprintf("=== %s (projects %d ↔ %d) ===", result.Resource, result.Project1ID, result.Project2ID),
+			})
+		} else {
+			for _, line := range lines {
+				fmt.Println(line)
+			}
+		}
+		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	case actionSave:
 		if err := promptAndSave(ctx, p, cmd, result, p1Name, p2Name); err != nil {
 			ui.Error(os.Stdout, fmt.Sprintf("Save failed: %v", err))
 		}
 		// After save, show menu again.
 		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
+	case actionSync:
+		runSyncFromCompare(ctx, cmd, result)
+		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	default:
 		return key
 	}
+}
+
+// syncMenuEntry describes a sync subcommand shown in the selection menu.
+type syncMenuEntry struct {
+	label      string // Display label for the menu.
+	subcommand string // Cobra subcommand name under "sync".
+}
+
+// syncMenuEntries defines available sync modes presented to the user.
+var syncMenuEntries = []syncMenuEntry{
+	{"Full migration (cases + shared steps)", "full"},
+	{"Suites", "suites"},
+	{"Sections", "sections"},
+	{"Shared steps", "shared-steps"},
+}
+
+// recommendedSyncIndex returns the index in syncMenuEntries best matching
+// the compare resource, or 0 (full) when nothing matches specifically.
+func recommendedSyncIndex(resource string) int {
+	switch resource {
+	case "suites":
+		return 1
+	case "sections":
+		return 2
+	case "shared_steps", "shared-steps":
+		return 3
+	default: // cases, "" or anything else → full
+		return 0
+	}
+}
+
+// runSyncFromCompare shows a sync-mode selection menu and invokes the
+// chosen sync subcommand with --src-project/--dst-project pre-filled.
+// Remaining interactive questions (suite, backup, etc.) are handled by sync.
+func runSyncFromCompare(ctx context.Context, compareCmd *cobra.Command, result CompareResult) {
+	if compareCmd == nil {
+		ui.Infof(os.Stdout, "Sync is not available (no command context).")
+		fmt.Println()
+		return
+	}
+
+	p := interactive.PrompterFromContext(ctx)
+
+	// Build the menu labels, marking the recommended option.
+	recommended := recommendedSyncIndex(result.Resource)
+	labels := make([]string, len(syncMenuEntries))
+	for i, e := range syncMenuEntries {
+		if i == recommended {
+			labels[i] = e.label + " ★"
+		} else {
+			labels[i] = e.label
+		}
+	}
+
+	fmt.Println()
+	ui.Infof(os.Stdout, "Pre-filled from compare: src-project=%d, dst-project=%d",
+		result.Project1ID, result.Project2ID)
+
+	idx, _, err := p.Select("What do you want to migrate?", labels)
+	if err != nil {
+		if interactive.IsGoBack(err) || interactive.IsExit(err) {
+			return
+		}
+		ui.Error(os.Stdout, fmt.Sprintf("Selection failed: %v", err))
+		return
+	}
+
+	syncSub := syncMenuEntries[idx].subcommand
+
+	root := compareCmd.Root()
+	syncCmd, _, err := root.Find([]string{"sync", syncSub})
+	if err != nil || syncCmd == nil || syncCmd.Name() == root.Name() {
+		fmt.Println()
+		ui.Error(os.Stdout, fmt.Sprintf("Could not find 'gotr sync %s' command.", syncSub))
+		fmt.Println()
+		return
+	}
+
+	fmt.Println()
+	ui.Infof(os.Stdout, "Starting: gotr sync %s (src-project=%d, dst-project=%d)",
+		syncSub, result.Project1ID, result.Project2ID)
+	fmt.Println()
+
+	// Pre-fill flags known from compare. Reset them after sync finishes
+	// to avoid stale state on repeated invocations.
+	setFlag := func(name, value string) {
+		if syncCmd.Flags().Lookup(name) != nil {
+			_ = syncCmd.Flags().Set(name, value)
+		}
+	}
+	resetFlag := func(name, zero string) {
+		if f := syncCmd.Flags().Lookup(name); f != nil {
+			_ = syncCmd.Flags().Set(name, zero)
+			f.Changed = false
+		}
+	}
+
+	setFlag("src-project", fmt.Sprintf("%d", result.Project1ID))
+	setFlag("dst-project", fmt.Sprintf("%d", result.Project2ID))
+
+	defer func() {
+		resetFlag("src-project", "0")
+		resetFlag("dst-project", "0")
+		resetFlag("src-suite", "0")
+		resetFlag("dst-suite", "0")
+	}()
+
+	// Propagate context (prompter, client, cancellation).
+	syncCmd.SetContext(ctx)
+
+	// RunE handles the rest interactively (suite selection, snapshot,
+	// confirmation, etc.) — the full protection chain of the sync command.
+	if err := syncCmd.RunE(syncCmd, nil); err != nil {
+		if interactive.IsGoBack(err) || interactive.IsExit(err) {
+			return
+		}
+		ui.Error(os.Stdout, fmt.Sprintf("Sync failed: %v", err))
+	}
+	fmt.Println()
 }
 
 // compareAllPostAction shows a post-action menu for compare-all with drill-down.
@@ -177,11 +315,23 @@ func promptAndSave(ctx context.Context, p interactive.Prompter, cmd *cobra.Comma
 		return err
 	}
 	savePath := strings.TrimSpace(input)
+
+	// Resolve __DEFAULT__ to a real path so we can show it to the user.
 	if savePath == "" {
-		savePath = "__DEFAULT__"
+		ext := format
+		if ext == "table" {
+			ext = "txt"
+		}
+		exportsDir, _ := outpututils.GetExportsDir("compare")
+		_ = os.MkdirAll(exportsDir, 0o755)
+		savePath = exportsDir + "/" + outpututils.GenerateFilename("compare", ext)
 	}
 
-	return PrintCompareResult(cmd, result, p1Name, p2Name, format, savePath)
+	if err := PrintCompareResult(cmd, result, p1Name, p2Name, format, savePath); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // renderTableLines builds the compare table as a slice of strings (one per line)
@@ -201,12 +351,24 @@ func renderTableLines(result CompareResult, p1Name, p2Name string) []string {
 // --- Line rendering helpers (mirror the existing print* functions but return []string) ---
 
 func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName string) []string {
-	idWidth := 8
-	nameWidth := 70
-	widths := []int{idWidth, nameWidth}
-	totalInnerWidth := idWidth + nameWidth + 3*len(widths) - 1
+	numWidth := 5  // row number "#"
+	idWidth := 8   // TestRail ID
+	// Adaptive name width: fill remaining terminal space.
+	// Layout: │ # │ ID │ Name │  →  1 + (numW+2) + 1 + (idW+2) + 1 + (nameW+2) + 1
+	termW := interactive.TerminalWidth()
+	nameWidth := termW - numWidth - idWidth - 10 // 10 = borders + padding
+	if nameWidth < 30 {
+		nameWidth = 30
+	}
 
-	title := fmt.Sprintf("Only in project %d - %q", projectID, projectName)
+	widths := []int{numWidth, idWidth, nameWidth}
+	totalInnerWidth := 0
+	for _, w := range widths {
+		totalInnerWidth += w + 3
+	}
+	totalInnerWidth-- // correct for last column
+
+	title := fmt.Sprintf("Only in project %d — %q (%d items)", projectID, projectName, len(items))
 	var lines []string
 	lines = append(lines, hBorder("┌", "┬", "┐", widths))
 	lines = append(lines, headerLine(title, totalInnerWidth))
@@ -220,11 +382,15 @@ func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName str
 	}
 
 	lines = append(lines, separatorLine(widths))
-	lines = append(lines, rowLine([]string{"ID", "Name"}, widths))
+	lines = append(lines, rowLine([]string{"#", "ID", "Name"}, widths))
 	lines = append(lines, separatorLine(widths))
 
-	for _, item := range items {
-		lines = append(lines, rowLine([]string{fmt.Sprintf("%d", item.ID), item.Name}, widths))
+	for i, item := range items {
+		lines = append(lines, rowLine([]string{
+			fmt.Sprintf("%d", i+1),
+			fmt.Sprintf("%d", item.ID),
+			item.Name,
+		}, widths))
 	}
 
 	lines = append(lines, hBorder("└", "┴", "┘", widths))
@@ -233,16 +399,29 @@ func renderOnlyInProjectLines(items []ItemInfo, projectID int64, projectName str
 }
 
 func renderCommonLines(items []CommonItemInfo, pid1, pid2 int64) []string {
-	nameWidth := 50
-	id1Width := 12
-	id2Width := 12
-	statusWidth := 20
-	widths := []int{nameWidth, id1Width, id2Width, statusWidth}
-	totalInnerWidth := nameWidth + id1Width + id2Width + statusWidth + 3*len(widths) - 1
+	numWidth := 5
+	id1Width := 10
+	id2Width := 10
+	statusWidth := 10
+	fixedCols := numWidth + id1Width + id2Width + statusWidth
+	// Adaptive name: terminal width minus fixed columns minus borders/padding.
+	// 5 columns → 5*3-1 = 14 for borders+padding
+	termW := interactive.TerminalWidth()
+	nameWidth := termW - fixedCols - 16
+	if nameWidth < 30 {
+		nameWidth = 30
+	}
+	widths := []int{numWidth, nameWidth, id1Width, id2Width, statusWidth}
+	totalInnerWidth := 0
+	for _, w := range widths {
+		totalInnerWidth += w + 3
+	}
+	totalInnerWidth--
 
+	title := fmt.Sprintf("Common in both projects (%d items)", len(items))
 	var lines []string
 	lines = append(lines, hBorder("┌", "┬", "┐", widths))
-	lines = append(lines, headerLine("Common in both projects", totalInnerWidth))
+	lines = append(lines, headerLine(title, totalInnerWidth))
 
 	if len(items) == 0 {
 		lines = append(lines, separatorLine(widths))
@@ -254,19 +433,21 @@ func renderCommonLines(items []CommonItemInfo, pid1, pid2 int64) []string {
 
 	lines = append(lines, separatorLine(widths))
 	lines = append(lines, rowLine([]string{
+		"#",
 		"Name",
-		fmt.Sprintf("ID proj %d", pid1),
-		fmt.Sprintf("ID proj %d", pid2),
-		"ID status",
+		fmt.Sprintf("ID P%d", pid1),
+		fmt.Sprintf("ID P%d", pid2),
+		"Status",
 	}, widths))
 	lines = append(lines, separatorLine(widths))
 
-	for _, item := range items {
+	for i, item := range items {
 		status := "✓ Match"
 		if !item.IDsMatch {
 			status = "⚠ Differ"
 		}
 		lines = append(lines, rowLine([]string{
+			fmt.Sprintf("%d", i+1),
 			item.Name,
 			fmt.Sprintf("%d", item.ID1),
 			fmt.Sprintf("%d", item.ID2),
@@ -287,15 +468,25 @@ func renderIDMappingLines(items []CommonItemInfo) []string {
 		}
 	}
 
-	sourceWidth := 12
-	targetWidth := 12
-	nameWidth := 70
-	widths := []int{sourceWidth, targetWidth, nameWidth}
-	totalInnerWidth := sourceWidth + targetWidth + nameWidth + 3*len(widths) - 1
+	numWidth := 5
+	sourceWidth := 10
+	targetWidth := 10
+	termW := interactive.TerminalWidth()
+	nameWidth := termW - numWidth - sourceWidth - targetWidth - 13
+	if nameWidth < 30 {
+		nameWidth = 30
+	}
+	widths := []int{numWidth, sourceWidth, targetWidth, nameWidth}
+	totalInnerWidth := 0
+	for _, w := range widths {
+		totalInnerWidth += w + 3
+	}
+	totalInnerWidth--
 
+	title := fmt.Sprintf("ID mapping — for updates (%d items)", len(mappings))
 	var lines []string
 	lines = append(lines, hBorder("┌", "┬", "┐", widths))
-	lines = append(lines, headerLine("ID mapping (for updates)", totalInnerWidth))
+	lines = append(lines, headerLine(title, totalInnerWidth))
 
 	if len(mappings) == 0 {
 		lines = append(lines, separatorLine(widths))
@@ -306,11 +497,12 @@ func renderIDMappingLines(items []CommonItemInfo) []string {
 	}
 
 	lines = append(lines, separatorLine(widths))
-	lines = append(lines, rowLine([]string{"Source ID", "Target ID", "Name"}, widths))
+	lines = append(lines, rowLine([]string{"#", "Source ID", "Target ID", "Name"}, widths))
 	lines = append(lines, separatorLine(widths))
 
-	for _, item := range mappings {
+	for i, item := range mappings {
 		lines = append(lines, rowLine([]string{
+			fmt.Sprintf("%d", i+1),
 			fmt.Sprintf("%d", item.ID1),
 			fmt.Sprintf("%d", item.ID2),
 			item.Name,

--- a/cmd/compare/interactive_helpers.go
+++ b/cmd/compare/interactive_helpers.go
@@ -31,6 +31,11 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 	}
 	p := interactive.PrompterFromContext(ctx)
 
+	// Persist project IDs for downstream commands (session inheritance).
+	if s := interactive.SessionFromContext(ctx); s != nil {
+		s.SetProjects(result.Project1ID, result.Project2ID)
+	}
+
 	hasDifferences := len(result.OnlyInFirst) > 0 || len(result.OnlyInSecond) > 0
 	hasData := hasDifferences || len(result.Common) > 0
 
@@ -39,6 +44,7 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 		{Label: "📋 View detailed results", Key: actionDrillRes, Disabled: !hasData, Hint: "no data"},
 		{Label: "💾 Save results to file", Key: actionSave},
 		{Label: "→ Sync: migrate differences", Key: actionSync, Disabled: !hasDifferences, Hint: "no differences found"},
+		{Label: "📦 Snap: manage snapshots", Key: actionSnap},
 	}
 
 	key, err := interactive.ActionMenu(ctx, p, "Comparison complete. What next?", options)
@@ -68,6 +74,9 @@ func comparePostAction(ctx context.Context, cmd *cobra.Command, result CompareRe
 		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	case actionSync:
 		runSyncFromCompare(ctx, cmd, result)
+		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
+	case actionSnap:
+		runSnapFromPostAction(ctx, cmd)
 		return comparePostAction(ctx, cmd, result, p1Name, p2Name)
 	default:
 		return key
@@ -130,6 +139,11 @@ func runSyncFromCompare(ctx context.Context, compareCmd *cobra.Command, result C
 	ui.Infof(os.Stdout, "Pre-filled from compare: src-project=%d, dst-project=%d",
 		result.Project1ID, result.Project2ID)
 
+	// Persist project IDs for downstream commands (session inheritance).
+	if s := interactive.SessionFromContext(ctx); s != nil {
+		s.SetProjects(result.Project1ID, result.Project2ID)
+	}
+
 	idx, _, err := p.Select("What do you want to migrate?", labels)
 	if err != nil {
 		if interactive.IsGoBack(err) || interactive.IsExit(err) {
@@ -142,10 +156,10 @@ func runSyncFromCompare(ctx context.Context, compareCmd *cobra.Command, result C
 	syncSub := syncMenuEntries[idx].subcommand
 
 	root := compareCmd.Root()
-	syncCmd, _, err := root.Find([]string{"sync", syncSub})
-	if err != nil || syncCmd == nil || syncCmd.Name() == root.Name() {
+	syncCmd, err := interactive.FindSubcommand(root, "sync", syncSub)
+	if err != nil {
 		fmt.Println()
-		ui.Error(os.Stdout, fmt.Sprintf("Could not find 'gotr sync %s' command.", syncSub))
+		ui.Error(os.Stdout, err.Error())
 		fmt.Println()
 		return
 	}
@@ -193,6 +207,15 @@ func runSyncFromCompare(ctx context.Context, compareCmd *cobra.Command, result C
 	fmt.Println()
 }
 
+// runSnapFromPostAction launches the snap list command from a post-action menu.
+func runSnapFromPostAction(ctx context.Context, cmd *cobra.Command) {
+	fmt.Println()
+	if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
+		ui.Error(os.Stdout, err.Error())
+	}
+	fmt.Println()
+}
+
 // compareAllPostAction shows a post-action menu for compare-all with drill-down.
 // resources maps resource display names to their CompareResult.
 func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allResult, p1Name, p2Name string, pid1, pid2 int64) string {
@@ -201,10 +224,16 @@ func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allRe
 	}
 	p := interactive.PrompterFromContext(ctx)
 
+	// Persist project IDs for downstream commands (session inheritance).
+	if s := interactive.SessionFromContext(ctx); s != nil {
+		s.SetProjects(pid1, pid2)
+	}
+
 	options := []interactive.ActionOption{
 		{Label: interactive.OptExit, Key: actionExit},
 		{Label: "🔍 Drill-down: view resource details", Key: actionDrillRes},
 		{Label: "💾 Save results to file", Key: actionSave},
+		{Label: "📦 Snap: manage snapshots", Key: actionSnap},
 	}
 
 	key, err := interactive.ActionMenu(ctx, p, "Compare all complete. What next?", options)
@@ -219,6 +248,9 @@ func compareAllPostAction(ctx context.Context, cmd *cobra.Command, result *allRe
 	case actionSave:
 		// Save is handled by caller (save flags).
 		return actionSave
+	case actionSnap:
+		runSnapFromPostAction(ctx, cmd)
+		return compareAllPostAction(ctx, cmd, result, p1Name, p2Name, pid1, pid2)
 	default:
 		return key
 	}

--- a/cmd/compare/interactive_helpers_test.go
+++ b/cmd/compare/interactive_helpers_test.go
@@ -285,7 +285,7 @@ func TestComparePostAction_NonInteractive(t *testing.T) {
 
 func TestComparePostAction_Exit(t *testing.T) {
 	mock := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: interactive.OptExit})
+		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: interactive.OptExit, Raw: true})
 	ctx := interactive.WithPrompter(context.Background(), mock)
 
 	result := CompareResult{Resource: "cases"}
@@ -295,23 +295,29 @@ func TestComparePostAction_Exit(t *testing.T) {
 
 func TestComparePostAction_Sync(t *testing.T) {
 	mock := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 2, Value: "→ Sync: migrate differences"})
+		WithSelectResponses(
+			interactive.SelectResponse{Index: 3, Value: "→ Sync: migrate differences", Raw: true},
+			interactive.SelectResponse{Index: 0, Value: interactive.OptExit, Raw: true},
+		)
 	ctx := interactive.WithPrompter(context.Background(), mock)
 
 	result := CompareResult{
 		Resource:    "cases",
+		Project1ID:  30,
+		Project2ID:  31,
 		OnlyInFirst: []ItemInfo{{ID: 1, Name: "A"}},
 	}
 	action := comparePostAction(ctx, nil, result, "P1", "P2")
-	assert.Equal(t, actionSync, action)
+	// Sync now shows a hint and returns to the menu; next selection is Exit.
+	assert.Equal(t, actionExit, action)
 }
 
 func TestComparePostAction_SyncDisabledNoDiffs(t *testing.T) {
 	// When no differences, sync is disabled → disabled re-prompt loop → exit.
 	mock := interactive.NewMockPrompter().
 		WithSelectResponses(
-			interactive.SelectResponse{Index: 2, Value: "→ Sync: migrate differences"},
-			interactive.SelectResponse{Index: 0, Value: interactive.OptExit},
+			interactive.SelectResponse{Index: 3, Value: "→ Sync: migrate differences", Raw: true},
+			interactive.SelectResponse{Index: 0, Value: interactive.OptExit, Raw: true},
 		)
 	ctx := interactive.WithPrompter(context.Background(), mock)
 
@@ -344,7 +350,7 @@ func TestCollectDrillDownResources_SomeComplete(t *testing.T) {
 
 func TestCompareAllPostAction_Exit(t *testing.T) {
 	mock := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: interactive.OptExit})
+		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: interactive.OptExit, Raw: true})
 	ctx := interactive.WithPrompter(context.Background(), mock)
 
 	result := &allResult{}
@@ -354,7 +360,7 @@ func TestCompareAllPostAction_Exit(t *testing.T) {
 
 func TestCompareAllPostAction_Save(t *testing.T) {
 	mock := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 2, Value: "💾 Save results to file"})
+		WithSelectResponses(interactive.SelectResponse{Index: 2, Value: "💾 Save results to file", Raw: true})
 	ctx := interactive.WithPrompter(context.Background(), mock)
 
 	result := &allResult{}

--- a/cmd/compare/interactive_helpers_test.go
+++ b/cmd/compare/interactive_helpers_test.go
@@ -3,6 +3,7 @@ package compare
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Korrnals/gotr/internal/client"
@@ -213,4 +214,184 @@ func TestSuitesCmd_InteractivePids(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.NoError(t, err)
+}
+
+// ==================== Tests for renderTableLines ====================
+
+func TestRenderTableLines_Empty(t *testing.T) {
+	result := CompareResult{
+		Resource:   "labels",
+		Project1ID: 1,
+		Project2ID: 2,
+	}
+
+	lines := renderTableLines(result, "P1", "P2")
+	require.NotEmpty(t, lines)
+
+	joined := joinLines(lines)
+	assert.Contains(t, joined, "labels")
+	assert.Contains(t, joined, "(none)")
+}
+
+func TestRenderTableLines_WithData(t *testing.T) {
+	result := CompareResult{
+		Resource:     "suites",
+		Project1ID:   10,
+		Project2ID:   20,
+		OnlyInFirst:  []ItemInfo{{ID: 1, Name: "Suite A"}},
+		OnlyInSecond: []ItemInfo{{ID: 2, Name: "Suite B"}},
+		Common: []CommonItemInfo{
+			{Name: "Suite C", ID1: 3, ID2: 4, IDsMatch: true},
+			{Name: "Suite D", ID1: 5, ID2: 6, IDsMatch: false},
+		},
+	}
+
+	lines := renderTableLines(result, "Project Alpha", "Project Beta")
+	joined := joinLines(lines)
+
+	assert.Contains(t, joined, "Suite A")
+	assert.Contains(t, joined, "Suite B")
+	assert.Contains(t, joined, "Suite C")
+	assert.Contains(t, joined, "Suite D")
+	assert.Contains(t, joined, "✓ Match")
+	assert.Contains(t, joined, "⚠ Differ")
+	assert.Contains(t, joined, "ID mapping")
+}
+
+func TestRenderTableLines_NoIDMismatch(t *testing.T) {
+	result := CompareResult{
+		Resource:   "groups",
+		Project1ID: 1,
+		Project2ID: 2,
+		Common: []CommonItemInfo{
+			{Name: "Grp", ID1: 10, ID2: 10, IDsMatch: true},
+		},
+	}
+
+	lines := renderTableLines(result, "P1", "P2")
+	joined := joinLines(lines)
+	assert.Contains(t, joined, "(all IDs match)")
+}
+
+// ==================== Tests for comparePostAction ====================
+
+func TestComparePostAction_NonInteractive(t *testing.T) {
+	ctx := interactive.WithPrompter(context.Background(), interactive.NewNonInteractivePrompter())
+
+	result := CompareResult{Resource: "cases"}
+	action := comparePostAction(ctx, nil, result, "P1", "P2")
+	assert.Equal(t, actionExit, action)
+}
+
+func TestComparePostAction_Exit(t *testing.T) {
+	mock := interactive.NewMockPrompter().
+		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: interactive.OptExit})
+	ctx := interactive.WithPrompter(context.Background(), mock)
+
+	result := CompareResult{Resource: "cases"}
+	action := comparePostAction(ctx, nil, result, "P1", "P2")
+	assert.Equal(t, actionExit, action)
+}
+
+func TestComparePostAction_Sync(t *testing.T) {
+	mock := interactive.NewMockPrompter().
+		WithSelectResponses(interactive.SelectResponse{Index: 2, Value: "→ Sync: migrate differences"})
+	ctx := interactive.WithPrompter(context.Background(), mock)
+
+	result := CompareResult{
+		Resource:    "cases",
+		OnlyInFirst: []ItemInfo{{ID: 1, Name: "A"}},
+	}
+	action := comparePostAction(ctx, nil, result, "P1", "P2")
+	assert.Equal(t, actionSync, action)
+}
+
+func TestComparePostAction_SyncDisabledNoDiffs(t *testing.T) {
+	// When no differences, sync is disabled → disabled re-prompt loop → exit.
+	mock := interactive.NewMockPrompter().
+		WithSelectResponses(
+			interactive.SelectResponse{Index: 2, Value: "→ Sync: migrate differences"},
+			interactive.SelectResponse{Index: 0, Value: interactive.OptExit},
+		)
+	ctx := interactive.WithPrompter(context.Background(), mock)
+
+	result := CompareResult{Resource: "cases"}
+	action := comparePostAction(ctx, nil, result, "P1", "P2")
+	assert.Equal(t, actionExit, action)
+}
+
+// ==================== Tests for collectDrillDownResources ====================
+
+func TestCollectDrillDownResources_AllNil(t *testing.T) {
+	result := &allResult{}
+	entries := collectDrillDownResources(result)
+	assert.Empty(t, entries)
+}
+
+func TestCollectDrillDownResources_SomeComplete(t *testing.T) {
+	result := &allResult{
+		Cases:  &CompareResult{Resource: "cases", Status: CompareStatusComplete},
+		Suites: &CompareResult{Resource: "suites", Status: CompareStatusInterrupted},
+		Labels: &CompareResult{Resource: "labels", Status: CompareStatusComplete},
+	}
+	entries := collectDrillDownResources(result)
+	assert.Len(t, entries, 2) // cases + labels
+	assert.Equal(t, "Cases", entries[0].name)
+	assert.Equal(t, "Labels", entries[1].name)
+}
+
+// ==================== Tests for compareAllPostAction ====================
+
+func TestCompareAllPostAction_Exit(t *testing.T) {
+	mock := interactive.NewMockPrompter().
+		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: interactive.OptExit})
+	ctx := interactive.WithPrompter(context.Background(), mock)
+
+	result := &allResult{}
+	action := compareAllPostAction(ctx, nil, result, "P1", "P2", 1, 2)
+	assert.Equal(t, actionExit, action)
+}
+
+func TestCompareAllPostAction_Save(t *testing.T) {
+	mock := interactive.NewMockPrompter().
+		WithSelectResponses(interactive.SelectResponse{Index: 2, Value: "💾 Save results to file"})
+	ctx := interactive.WithPrompter(context.Background(), mock)
+
+	result := &allResult{}
+	action := compareAllPostAction(ctx, nil, result, "P1", "P2", 1, 2)
+	assert.Equal(t, actionSave, action)
+}
+
+// ==================== Tests for line rendering helpers ====================
+
+func TestHBorder(t *testing.T) {
+	line := hBorder("┌", "┬", "┐", []int{5, 10})
+	assert.True(t, strings.HasPrefix(line, "┌"))
+	assert.True(t, strings.HasSuffix(line, "┐"))
+	assert.Contains(t, line, "┬")
+}
+
+func TestRowLine(t *testing.T) {
+	line := rowLine([]string{"hello", "world"}, []int{10, 10})
+	assert.Contains(t, line, "hello")
+	assert.Contains(t, line, "world")
+	assert.True(t, strings.HasPrefix(line, "│"))
+	assert.True(t, strings.HasSuffix(line, "│"))
+}
+
+func TestHeaderLine(t *testing.T) {
+	line := headerLine("Title", 30)
+	assert.Contains(t, line, "Title")
+	assert.True(t, strings.HasPrefix(line, "│"))
+}
+
+func TestSeparatorLine(t *testing.T) {
+	line := separatorLine([]int{5, 10})
+	assert.True(t, strings.HasPrefix(line, "├"))
+	assert.True(t, strings.HasSuffix(line, "┤"))
+	assert.Contains(t, line, "┼")
+}
+
+func joinLines(lines []string) string {
+	return strings.Join(lines, "\n")
 }

--- a/cmd/compare/simple.go
+++ b/cmd/compare/simple.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/concurrency"
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -49,8 +50,16 @@ func newSimpleCompareCmd(resource, use, short, long string, fetchFn FetchFunc) *
 
 			elapsed := time.Since(startTime)
 
-			if err := PrintCompareResult(cmd, *result, project1Name, project2Name, format, savePath); err != nil {
-				return err
+			// In interactive mode with table format and no save — skip
+			// dumping the detail table. The user can view it via
+			// "📋 View detailed results" in the post-action menu.
+			isInteractiveTable := format == "table" && savePath == "" && !quiet &&
+				interactive.HasPrompterInContext(ctx) && !interactive.IsNonInteractive(ctx)
+
+			if !isInteractiveTable {
+				if err := PrintCompareResult(cmd, *result, project1Name, project2Name, format, savePath); err != nil {
+					return err
+				}
 			}
 
 			if !quiet {

--- a/cmd/compare/simple.go
+++ b/cmd/compare/simple.go
@@ -58,6 +58,11 @@ func newSimpleCompareCmd(resource, use, short, long string, fetchFn FetchFunc) *
 					len(result.OnlyInFirst), len(result.OnlyInSecond), len(result.Common), elapsed, result.Status)
 			}
 
+			// Post-action menu (interactive only, non-save).
+			if savePath == "" && !quiet {
+				comparePostAction(ctx, cmd, *result, project1Name, project2Name)
+			}
+
 			return nil
 		},
 	}

--- a/cmd/compare/types.go
+++ b/cmd/compare/types.go
@@ -124,7 +124,7 @@ func PrintCompareResult(cmd *cobra.Command, result CompareResult, project1Name, 
 				}
 				filePath := exportsDir + "/" + outpututils.GenerateFilename("compare", format)
 				if err := saveToFileWithPath(result, format, filePath); err != nil {
-					return err
+					return fmt.Errorf("PrintCompareResult: %w", err)
 				}
 				// Message is printed by saveToFile
 				return nil
@@ -143,7 +143,7 @@ func PrintCompareResult(cmd *cobra.Command, result CompareResult, project1Name, 
 		switch format {
 		case "json", "yaml", "csv":
 			if err := saveToFileWithPath(result, format, savePath); err != nil {
-				return err
+				return fmt.Errorf("PrintCompareResult: %w", err)
 			}
 			if q, _ := cmd.Flags().GetBool("quiet"); !q {
 				fmt.Println()
@@ -253,6 +253,7 @@ func printTable(result CompareResult, project1Name, project2Name string) error {
 }
 
 // printOnlyInProjectTable prints a table for items only in one project
+//nolint:unused // Kept as legacy renderer for compatibility with older output paths.
 func printOnlyInProjectTable(items []ItemInfo, projectID int64, projectName string) {
 	// Column widths are widened for long names.
 	idWidth := 8
@@ -291,6 +292,7 @@ func printOnlyInProjectTable(items []ItemInfo, projectID int64, projectName stri
 }
 
 // printCommonTable prints a table for common items
+//nolint:unused // Kept as legacy renderer for compatibility with older output paths.
 func printCommonTable(items []CommonItemInfo, project1ID, project2ID int64) {
 	// Column widths are widened for long names.
 	nameWidth := 50
@@ -344,6 +346,7 @@ func printCommonTable(items []CommonItemInfo, project1ID, project2ID int64) {
 }
 
 // printIDMappingTable prints a table for ID mapping (items with different IDs)
+//nolint:unused // Kept as legacy renderer for compatibility with older output paths.
 func printIDMappingTable(items []CommonItemInfo) {
 	// Filter items with different IDs
 	var mappings []CommonItemInfo
@@ -421,27 +424,27 @@ func printCSV(result CompareResult) error {
 
 	// Header
 	if err := writer.Write([]string{"Type", "Name", "ID Project 1", "ID Project 2"}); err != nil {
-		return err
+		return fmt.Errorf("printCSV: %w", err)
 	}
 
 	// Only in first
 	for _, item := range result.OnlyInFirst {
 		if err := writer.Write([]string{"Only in Project 1", item.Name, fmt.Sprintf("%d", item.ID), ""}); err != nil {
-			return err
+			return fmt.Errorf("printCSV: %w", err)
 		}
 	}
 
 	// Only in second
 	for _, item := range result.OnlyInSecond {
 		if err := writer.Write([]string{"Only in Project 2", item.Name, "", fmt.Sprintf("%d", item.ID)}); err != nil {
-			return err
+			return fmt.Errorf("printCSV: %w", err)
 		}
 	}
 
 	// Common
 	for _, item := range result.Common {
 		if err := writer.Write([]string{"Common", item.Name, fmt.Sprintf("%d", item.ID1), fmt.Sprintf("%d", item.ID2)}); err != nil {
-			return err
+			return fmt.Errorf("printCSV: %w", err)
 		}
 	}
 
@@ -486,27 +489,27 @@ func saveCSV(result CompareResult, savePath string) error {
 
 	// Header
 	if err := writer.Write([]string{"Type", "Name", "ID Project 1", "ID Project 2"}); err != nil {
-		return err
+		return fmt.Errorf("saveCSV: %w", err)
 	}
 
 	// Only in first
 	for _, item := range result.OnlyInFirst {
 		if err := writer.Write([]string{"Only in Project 1", item.Name, fmt.Sprintf("%d", item.ID), ""}); err != nil {
-			return err
+			return fmt.Errorf("saveCSV: %w", err)
 		}
 	}
 
 	// Only in second
 	for _, item := range result.OnlyInSecond {
 		if err := writer.Write([]string{"Only in Project 2", item.Name, "", fmt.Sprintf("%d", item.ID)}); err != nil {
-			return err
+			return fmt.Errorf("saveCSV: %w", err)
 		}
 	}
 
 	// Common
 	for _, item := range result.Common {
 		if err := writer.Write([]string{"Common", item.Name, fmt.Sprintf("%d", item.ID1), fmt.Sprintf("%d", item.ID2)}); err != nil {
-			return err
+			return fmt.Errorf("saveCSV: %w", err)
 		}
 	}
 

--- a/cmd/compare/types.go
+++ b/cmd/compare/types.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/flags"
+	"github.com/Korrnals/gotr/internal/interactive"
 	outpututils "github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/ui"
 	"github.com/spf13/cobra"
@@ -233,22 +234,21 @@ func printSeparator(widths []int) {
 	fmt.Println("├" + strings.Join(parts, "┼") + "┤")
 }
 
-// printTable prints the result in table format
+// printTable prints the result in table format.
+// If stdout is a TTY and the output is long, uses the interactive pager.
 func printTable(result CompareResult, project1Name, project2Name string) error {
-	fmt.Printf("\n=== Comparison: %s (projects %d ↔ %d) ===\n\n", result.Resource, result.Project1ID, result.Project2ID)
+	lines := renderTableLines(result, project1Name, project2Name)
 
-	// Table 1: Only in Project 1
-	printOnlyInProjectTable(result.OnlyInFirst, result.Project1ID, project1Name)
+	if interactive.ShouldPage(len(lines)) {
+		return interactive.Pager(interactive.PagerConfig{
+			Lines:  lines,
+			Header: fmt.Sprintf("=== Comparison: %s (projects %d ↔ %d) ===", result.Resource, result.Project1ID, result.Project2ID),
+		})
+	}
 
-	// Table 2: Only in Project 2
-	printOnlyInProjectTable(result.OnlyInSecond, result.Project2ID, project2Name)
-
-	// Table 3: Common items
-	printCommonTable(result.Common, result.Project1ID, result.Project2ID)
-
-	// Table 4: ID Mapping (for items with different IDs)
-	printIDMappingTable(result.Common)
-
+	for _, line := range lines {
+		fmt.Println(line)
+	}
 	return nil
 }
 

--- a/cmd/configurations/add_config.go
+++ b/cmd/configurations/add_config.go
@@ -85,7 +85,11 @@ test plans with multiple configurations.`,
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Configuration added (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "configurations")
+			if err := output.OutputResult(cmd, resp, "configurations"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/configurations/add_group.go
+++ b/cmd/configurations/add_group.go
@@ -85,7 +85,11 @@ individual configurations to it.`,
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Group created (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "configurations")
+			if err := output.OutputResult(cmd, resp, "configurations"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/configurations/delete_config.go
+++ b/cmd/configurations/delete_config.go
@@ -75,6 +75,7 @@ is not used in active test plans.`,
 			}
 
 			ui.Successf(os.Stdout, "Configuration %d deleted", configID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/configurations/delete_group.go
+++ b/cmd/configurations/delete_group.go
@@ -76,6 +76,7 @@ in active test plans.`,
 			}
 
 			ui.Successf(os.Stdout, "Group %d deleted", groupID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/configurations/interactive_helpers.go
+++ b/cmd/configurations/interactive_helpers.go
@@ -72,13 +72,27 @@ func selectGroupID(ctx context.Context, groups data.GetConfigsResponse) (int64, 
 
 // selectGroupIndex prompts for group selection and returns the chosen index.
 func selectGroupIndex(ctx context.Context, groups data.GetConfigsResponse) (int, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(groups))
-	for i, group := range groups {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, group.ID, group.Name))
+	if len(groups) == 0 {
+		return 0, fmt.Errorf("no configuration groups found")
 	}
 
-	idx, _, err := p.Select("Select configuration group:", options)
+	p := interactive.PrompterFromContext(ctx)
+
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(groups))
+	for i, group := range groups {
+		rows[i] = []string{fmt.Sprintf("%d", group.ID), group.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select configuration group:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select configuration group: %w", err)
 	}
@@ -89,12 +103,22 @@ func selectGroupIndex(ctx context.Context, groups data.GetConfigsResponse) (int,
 // selectConfigID prompts for configuration selection and returns the chosen config ID.
 func selectConfigID(ctx context.Context, configs []data.Config) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(configs))
-	for i, cfg := range configs {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, cfg.ID, cfg.Name))
-	}
 
-	idx, _, err := p.Select("Select configuration:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(configs))
+	for i, cfg := range configs {
+		rows[i] = []string{fmt.Sprintf("%d", cfg.ID), cfg.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select configuration:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select configuration: %w", err)
 	}

--- a/cmd/configurations/interactive_helpers_test.go
+++ b/cmd/configurations/interactive_helpers_test.go
@@ -288,7 +288,7 @@ func TestSelectGroupID_TableDriven(t *testing.T) {
 			ctx: interactive.WithPrompter(context.Background(),
 				interactive.NewMockPrompter()),
 			groups:      nil,
-			wantErrPart: "select options list is empty",
+			wantErrPart: "no configuration groups found",
 		},
 	}
 

--- a/cmd/configurations/update_config.go
+++ b/cmd/configurations/update_config.go
@@ -79,7 +79,11 @@ func newUpdateConfigCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Configuration %d updated", configID)
-			return output.OutputResult(cmd, resp, "configurations")
+			if err := output.OutputResult(cmd, resp, "configurations"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/configurations/update_group.go
+++ b/cmd/configurations/update_group.go
@@ -79,7 +79,11 @@ func newUpdateGroupCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Group %d updated", groupID)
-			return output.OutputResult(cmd, resp, "configurations")
+			if err := output.OutputResult(cmd, resp, "configurations"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/datasets/add.go
+++ b/cmd/datasets/add.go
@@ -72,7 +72,11 @@ or other API methods.`,
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Dataset created (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "datasets")
+			if err := output.OutputResult(cmd, resp, "datasets"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/datasets/delete.go
+++ b/cmd/datasets/delete.go
@@ -66,6 +66,7 @@ Use --dry-run to preview before deleting.`,
 			}
 
 			ui.Successf(os.Stdout, "Dataset %d deleted", datasetID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/datasets/interactive_helpers.go
+++ b/cmd/datasets/interactive_helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 )
 
 // resolveProjectIDInteractive prompts the user to select a project interactively.
@@ -17,7 +16,8 @@ func resolveProjectIDInteractive(ctx context.Context, cli client.ClientInterface
 
 // resolveDatasetIDInteractive prompts the user to select a dataset interactively.
 func resolveDatasetIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
-	projectID, err := resolveProjectIDInteractive(ctx, cli)
+	p := interactive.PrompterFromContext(ctx)
+	projectID, err := interactive.SelectProject(ctx, p, cli, "")
 	if err != nil {
 		return 0, err
 	}
@@ -30,21 +30,5 @@ func resolveDatasetIDInteractive(ctx context.Context, cli client.ClientInterface
 		return 0, fmt.Errorf("no datasets found in project %d", projectID)
 	}
 
-	return selectDatasetID(ctx, datasets)
-}
-
-// selectDatasetID prompts for dataset selection and returns the chosen dataset ID.
-func selectDatasetID(ctx context.Context, datasets data.GetDatasetsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(datasets))
-	for i, dataset := range datasets {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, dataset.ID, dataset.Name))
-	}
-
-	idx, _, err := p.Select("Select dataset:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select dataset: %w", err)
-	}
-
-	return datasets[idx].ID, nil
+	return interactive.SelectDataset(ctx, p, datasets, "")
 }

--- a/cmd/datasets/update.go
+++ b/cmd/datasets/update.go
@@ -70,7 +70,11 @@ use the TestRail web interface.`,
 			}
 
 			ui.Successf(os.Stdout, "Dataset %d updated", datasetID)
-			return output.OutputResult(cmd, resp, "datasets")
+			if err := output.OutputResult(cmd, resp, "datasets"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -47,6 +47,7 @@ func init() {
 	snap.RegisterFlags(deleteCmd)
 }
 
+//nolint:gocyclo // Endpoint routing with snapshot hooks is intentionally explicit.
 func runDelete(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	if len(args) == 0 && !interactive.HasPrompterInContext(ctx) {
@@ -62,19 +63,19 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	} else {
 		selectedEndpoint, err := selectDeleteEndpoint(p)
 		if err != nil {
-			return err
+			return fmt.Errorf("runDelete: %w", err)
 		}
 		endpoint = selectedEndpoint
 	}
 
 	id, err := parseDeleteIDArg(args)
 	if err != nil {
-		return err
+		return fmt.Errorf("runDelete: %w", err)
 	}
 	if id == 0 {
 		id, err = resolveDeleteID(ctx, p, cli, endpoint)
 		if err != nil {
-			return err
+			return fmt.Errorf("runDelete: %w", err)
 		}
 	}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/snap"
 	"github.com/spf13/cobra"
@@ -312,7 +311,7 @@ func resolveDeleteCase(ctx context.Context, p interactive.Prompter, cli client.C
 			if err != nil {
 				return 0, fmt.Errorf("failed to get cases for project %d suite %d: %w", projectID, suiteID, err)
 			}
-			caseID, err := selectCaseID(ctx, p, cases)
+			caseID, err := interactive.SelectCase(ctx, p, cases, "", true)
 			if err != nil {
 				if interactive.IsGoBack(err) {
 					step = 1
@@ -356,7 +355,7 @@ func resolveDeleteSharedStep(ctx context.Context, p interactive.Prompter, cli cl
 		if err != nil {
 			return 0, fmt.Errorf("failed to get shared steps for project %d: %w", projectID, err)
 		}
-		stepID, err := selectSharedStepID(p, steps)
+		stepID, err := interactive.SelectSharedStep(ctx, p, steps, "", true)
 		if err != nil {
 			if interactive.IsGoBack(err) {
 				continue
@@ -365,43 +364,6 @@ func resolveDeleteSharedStep(ctx context.Context, p interactive.Prompter, cli cl
 		}
 		return stepID, nil
 	}
-}
-
-func selectCaseID(ctx context.Context, p interactive.Prompter, cases data.GetCasesResponse) (int64, error) {
-	_ = ctx
-	if len(cases) == 0 {
-		return 0, fmt.Errorf("no cases found")
-	}
-
-	options := make([]string, 0, len(cases))
-	for i, kase := range cases {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, kase.ID, kase.Title))
-	}
-
-	idx, _, err := p.Select("Select case:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select case: %w", err)
-	}
-
-	return cases[idx].ID, nil
-}
-
-func selectSharedStepID(p interactive.Prompter, steps data.GetSharedStepsResponse) (int64, error) {
-	if len(steps) == 0 {
-		return 0, fmt.Errorf("no shared steps found")
-	}
-
-	options := make([]string, 0, len(steps))
-	for i, step := range steps {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, step.ID, step.Title))
-	}
-
-	idx, _, err := p.Select("Select shared step:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select shared step: %w", err)
-	}
-
-	return steps[idx].ID, nil
 }
 
 // runDeleteDryRun performs a dry-run for the delete command.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -223,71 +223,148 @@ func resolveDeleteProject(ctx context.Context, p interactive.Prompter, cli clien
 }
 
 func resolveDeleteSuite(ctx context.Context, p interactive.Prompter, cli client.ClientInterface) (int64, error) {
-	projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for suite deletion:")
-	if err != nil {
-		return 0, err
+	for {
+		projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for suite deletion:")
+		if err != nil {
+			return 0, err
+		}
+		suites, err := cli.GetSuites(ctx, projectID)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get suites for project %d: %w", projectID, err)
+		}
+		suiteID, err := interactive.SelectSuite(ctx, p, suites, "", true)
+		if err != nil {
+			if interactive.IsGoBack(err) {
+				continue
+			}
+			return 0, err
+		}
+		return suiteID, nil
 	}
-	suites, err := cli.GetSuites(ctx, projectID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get suites for project %d: %w", projectID, err)
-	}
-	return interactive.SelectSuite(ctx, p, suites, "")
 }
 
 func resolveDeleteSection(ctx context.Context, p interactive.Prompter, cli client.ClientInterface) (int64, error) {
-	projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for section deletion:")
-	if err != nil {
-		return 0, err
+	var projectID, suiteID int64
+	step := 0 // 0=project, 1=suite, 2=section
+	for {
+		switch step {
+		case 0:
+			var err error
+			projectID, err = interactive.SelectProject(ctx, p, cli, "Select project for section deletion:")
+			if err != nil {
+				return 0, err
+			}
+			step = 1
+		case 1:
+			var err error
+			suiteID, err = interactive.SelectSuiteForProject(ctx, p, cli, projectID, "Select suite for section deletion:", true)
+			if err != nil {
+				if interactive.IsGoBack(err) {
+					step = 0
+					continue
+				}
+				return 0, err
+			}
+			step = 2
+		case 2:
+			sections, err := cli.GetSections(ctx, projectID, suiteID)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get sections for project %d suite %d: %w", projectID, suiteID, err)
+			}
+			sectionID, err := interactive.SelectSection(ctx, p, sections, "", true)
+			if err != nil {
+				if interactive.IsGoBack(err) {
+					step = 1
+					continue
+				}
+				return 0, err
+			}
+			return sectionID, nil
+		}
 	}
-	suiteID, err := interactive.SelectSuiteForProject(ctx, p, cli, projectID, "Select suite for section deletion:")
-	if err != nil {
-		return 0, err
-	}
-	sections, err := cli.GetSections(ctx, projectID, suiteID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get sections for project %d suite %d: %w", projectID, suiteID, err)
-	}
-	return interactive.SelectSection(ctx, p, sections, "")
 }
 
 func resolveDeleteCase(ctx context.Context, p interactive.Prompter, cli client.ClientInterface) (int64, error) {
-	projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for case deletion:")
-	if err != nil {
-		return 0, err
+	var projectID, suiteID int64
+	step := 0 // 0=project, 1=suite, 2=case
+	for {
+		switch step {
+		case 0:
+			var err error
+			projectID, err = interactive.SelectProject(ctx, p, cli, "Select project for case deletion:")
+			if err != nil {
+				return 0, err
+			}
+			step = 1
+		case 1:
+			var err error
+			suiteID, err = interactive.SelectSuiteForProject(ctx, p, cli, projectID, "Select suite for case deletion:", true)
+			if err != nil {
+				if interactive.IsGoBack(err) {
+					step = 0
+					continue
+				}
+				return 0, err
+			}
+			step = 2
+		case 2:
+			cases, err := cli.GetCases(ctx, projectID, suiteID, 0)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get cases for project %d suite %d: %w", projectID, suiteID, err)
+			}
+			caseID, err := selectCaseID(ctx, p, cases)
+			if err != nil {
+				if interactive.IsGoBack(err) {
+					step = 1
+					continue
+				}
+				return 0, err
+			}
+			return caseID, nil
+		}
 	}
-	suiteID, err := interactive.SelectSuiteForProject(ctx, p, cli, projectID, "Select suite for case deletion:")
-	if err != nil {
-		return 0, err
-	}
-	cases, err := cli.GetCases(ctx, projectID, suiteID, 0)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get cases for project %d suite %d: %w", projectID, suiteID, err)
-	}
-	return selectCaseID(ctx, p, cases)
 }
 
 func resolveDeleteRun(ctx context.Context, p interactive.Prompter, cli client.ClientInterface) (int64, error) {
-	projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for run deletion:")
-	if err != nil {
-		return 0, err
+	for {
+		projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for run deletion:")
+		if err != nil {
+			return 0, err
+		}
+		runs, err := cli.GetRuns(ctx, projectID)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get runs for project %d: %w", projectID, err)
+		}
+		runID, err := interactive.SelectRun(ctx, p, runs, "", true)
+		if err != nil {
+			if interactive.IsGoBack(err) {
+				continue
+			}
+			return 0, err
+		}
+		return runID, nil
 	}
-	runs, err := cli.GetRuns(ctx, projectID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get runs for project %d: %w", projectID, err)
-	}
-	return interactive.SelectRun(ctx, p, runs, "")
 }
 
 func resolveDeleteSharedStep(ctx context.Context, p interactive.Prompter, cli client.ClientInterface) (int64, error) {
-	projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for shared-step deletion:")
-	if err != nil {
-		return 0, err
+	for {
+		projectID, err := interactive.SelectProject(ctx, p, cli, "Select project for shared-step deletion:")
+		if err != nil {
+			return 0, err
+		}
+		steps, err := cli.GetSharedSteps(ctx, projectID)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get shared steps for project %d: %w", projectID, err)
+		}
+		stepID, err := selectSharedStepID(p, steps)
+		if err != nil {
+			if interactive.IsGoBack(err) {
+				continue
+			}
+			return 0, err
+		}
+		return stepID, nil
 	}
-	steps, err := cli.GetSharedSteps(ctx, projectID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get shared steps for project %d: %w", projectID, err)
-	}
-	return selectSharedStepID(p, steps)
 }
 
 func selectCaseID(ctx context.Context, p interactive.Prompter, cases data.GetCasesResponse) (int64, error) {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -86,34 +86,41 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	// Route by endpoint
+	var deleteErr error
 	switch endpoint {
 	case "project":
 		snap.HookMutation(ctx, snap.Mutation{Cmd: cmd, Op: snap.OpDelete, EntityType: "project",
 			EntityIDs: []int64{id}, Tier: snap.Tier2,
 			FetchFn: func(ctx context.Context) (interface{}, error) { return cli.GetProject(ctx, id) }})
-		return cli.DeleteProject(ctx, id)
+		deleteErr = cli.DeleteProject(ctx, id)
 	case "suite":
 		snap.HookMutation(ctx, snap.Mutation{Cmd: cmd, Op: snap.OpDelete, EntityType: "suite",
 			EntityIDs: []int64{id}, Tier: snap.Tier2,
 			FetchFn: func(ctx context.Context) (interface{}, error) { return cli.GetSuite(ctx, id) }})
-		return cli.DeleteSuite(ctx, id)
+		deleteErr = cli.DeleteSuite(ctx, id)
 	case "section":
-		return deleteSectionWithSnap(cmd, cli, ctx, id)
+		deleteErr = deleteSectionWithSnap(cmd, cli, ctx, id)
 	case "case":
-		return deleteCaseWithSnap(cmd, cli, ctx, id)
+		deleteErr = deleteCaseWithSnap(cmd, cli, ctx, id)
 	case "run":
 		snap.HookMutation(ctx, snap.Mutation{Cmd: cmd, Op: snap.OpDelete, EntityType: "run",
 			EntityIDs: []int64{id}, Tier: snap.Tier2,
 			FetchFn: func(ctx context.Context) (interface{}, error) { return cli.GetRun(ctx, id) }})
-		return cli.DeleteRun(ctx, id)
+		deleteErr = cli.DeleteRun(ctx, id)
 	case "shared-step":
 		snap.HookMutation(ctx, snap.Mutation{Cmd: cmd, Op: snap.OpDelete, EntityType: "shared_step",
 			EntityIDs: []int64{id}, Tier: snap.Tier2,
 			FetchFn: func(ctx context.Context) (interface{}, error) { return cli.GetSharedStep(ctx, id) }})
-		return cli.DeleteSharedStep(ctx, id, 0)
+		deleteErr = cli.DeleteSharedStep(ctx, id, 0)
 	default:
 		return fmt.Errorf("unsupported endpoint: %s", endpoint)
 	}
+	if deleteErr != nil {
+		return deleteErr
+	}
+
+	interactive.MutationPostAction(ctx, cmd)
+	return nil
 }
 
 // deleteSectionWithSnap creates a cascade snapshot before deleting a section.

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -72,29 +72,6 @@ func TestDelete_Project_AutoSelectID_Success(t *testing.T) {
 	assert.True(t, called)
 }
 
-func TestSelectCaseID(t *testing.T) {
-	p := interactive.NewMockPrompter().WithSelectResponses(interactive.SelectResponse{Index: 1})
-	cases := data.GetCasesResponse{
-		{ID: 100, Title: "Case A"},
-		{ID: 200, Title: "Case B"},
-	}
-
-	id, err := selectCaseID(context.Background(), p, cases)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(200), id)
-}
-
-func TestSelectSharedStepID(t *testing.T) {
-	p := interactive.NewMockPrompter().WithSelectResponses(interactive.SelectResponse{Index: 0})
-	steps := data.GetSharedStepsResponse{
-		{ID: 555, Title: "Step A"},
-	}
-
-	id, err := selectSharedStepID(p, steps)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(555), id)
-}
-
 func TestRunDeleteDryRun_SwitchEndpoints(t *testing.T) {
 	dr := output.NewDryRunPrinter("delete")
 
@@ -469,53 +446,6 @@ func TestDelete_ZeroID_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid ID")
 }
 
-func TestSelectCaseID_EmptyList_Error(t *testing.T) {
-	p := interactive.NewMockPrompter()
-	cases := data.GetCasesResponse{}
-
-	id, err := selectCaseID(context.Background(), p, cases)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no cases found")
-	assert.Equal(t, int64(0), id)
-}
-
-func TestSelectCaseID_MultipleOptions(t *testing.T) {
-	p := interactive.NewMockPrompter().WithSelectResponses(interactive.SelectResponse{Index: 2})
-	cases := data.GetCasesResponse{
-		{ID: 100, Title: "Case 1"},
-		{ID: 200, Title: "Case 2"},
-		{ID: 300, Title: "Case 3"},
-		{ID: 400, Title: "Case 4"},
-	}
-
-	id, err := selectCaseID(context.Background(), p, cases)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(300), id)
-}
-
-func TestSelectSharedStepID_MultipleOptions(t *testing.T) {
-	p := interactive.NewMockPrompter().WithSelectResponses(interactive.SelectResponse{Index: 1})
-	steps := data.GetSharedStepsResponse{
-		{ID: 555, Title: "Step A"},
-		{ID: 666, Title: "Step B"},
-		{ID: 777, Title: "Step C"},
-	}
-
-	id, err := selectSharedStepID(p, steps)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(666), id)
-}
-
-func TestSelectSharedStepID_EmptyList_Error(t *testing.T) {
-	p := interactive.NewMockPrompter()
-	steps := data.GetSharedStepsResponse{}
-
-	id, err := selectSharedStepID(p, steps)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no shared steps found")
-	assert.Equal(t, int64(0), id)
-}
-
 func TestResolveDeleteID_UnsupportedEndpoint(t *testing.T) {
 	id, err := resolveDeleteID(context.Background(), interactive.NewMockPrompter(), &client.MockClient{}, "weird")
 	assert.Error(t, err)
@@ -620,16 +550,6 @@ func TestResolveDeleteID_ErrorBranches(t *testing.T) {
 	})
 }
 
-func TestSelectSharedStepID_SelectError(t *testing.T) {
-	p := interactive.NewNonInteractivePrompter()
-	steps := data.GetSharedStepsResponse{{ID: 101, Title: "Step X"}}
-
-	id, err := selectSharedStepID(p, steps)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to select shared step")
-	assert.Zero(t, id)
-}
-
 // ============= LAYER 2: delete.go missing branches =============
 
 func TestDelete_NoArgs_NoPrompter_Error(t *testing.T) {
@@ -658,16 +578,6 @@ cmd.SetArgs([]string{"project"}) // supply endpoint, id=0 → resolveDeleteID
 
 err := cmd.Execute()
 assert.Error(t, err)
-}
-
-func TestSelectCaseID_SelectError(t *testing.T) {
-p := interactive.NewNonInteractivePrompter()
-cases := data.GetCasesResponse{{ID: 100, Title: "Case 1"}}
-
-id, err := selectCaseID(context.Background(), p, cases)
-assert.Error(t, err)
-assert.Contains(t, err.Error(), "failed to select case")
-assert.Zero(t, id)
 }
 
 func TestResolveDeleteID_SelectProjectErrors(t *testing.T) {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -115,7 +115,10 @@ func resolveExportInputs(cmd *cobra.Command, args []string) (resource, endpoint,
 		if !interactive.HasPrompterInContext(ctx) {
 			return "", "", "", fmt.Errorf("resource required: gotr export <resource> <endpoint> [id]")
 		}
-		idx, _, err := p.Select("Select export resource:", ValidResources)
+		idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+			Prompt: "Select export resource:",
+			Items:  ValidResources,
+		})
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to select resource: %w", err)
 		}
@@ -136,7 +139,10 @@ func resolveExportInputs(cmd *cobra.Command, args []string) (resource, endpoint,
 		if len(endpointOptions) == 0 {
 			return "", "", "", fmt.Errorf("no export endpoints found for resource: %s", resource)
 		}
-		idx, _, err := p.Select("Select export endpoint:", endpointOptions)
+		idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+			Prompt: "Select export endpoint:",
+			Items:  endpointOptions,
+		})
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to select endpoint: %w", err)
 		}

--- a/cmd/get/cases.go
+++ b/cmd/get/cases.go
@@ -177,7 +177,7 @@ func newCaseCmd(getClient func(*cobra.Command) client.ClientInterface) *cobra.Co
 					return fmt.Errorf("no cases found in suite %d", suiteID)
 				}
 
-				id, err = selectCaseID(ctx, cases)
+				id, err = interactive.SelectCase(ctx, interactive.PrompterFromContext(ctx), cases, "")
 				if err != nil {
 					return err
 				}

--- a/cmd/get/history.go
+++ b/cmd/get/history.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"context"
-
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/flags"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +62,7 @@ func newCaseHistoryCmd(getClient func(*cobra.Command) client.ClientInterface) *c
 					return fmt.Errorf("no cases found in suite %d", suiteID)
 				}
 
-				id, err = selectCaseID(ctx, cases)
+				id, err = interactive.SelectCase(ctx, interactive.PrompterFromContext(ctx), cases, "")
 				if err != nil {
 					return err
 				}
@@ -120,7 +117,7 @@ func newSharedStepHistoryCmd(getClient func(*cobra.Command) client.ClientInterfa
 					return fmt.Errorf("no shared steps found in project %d", projectID)
 				}
 
-				id, err = selectSharedStepID(ctx, steps)
+				id, err = interactive.SelectSharedStep(ctx, interactive.PrompterFromContext(ctx), steps, "")
 				if err != nil {
 					return err
 				}
@@ -134,21 +131,6 @@ func newSharedStepHistoryCmd(getClient func(*cobra.Command) client.ClientInterfa
 			return handleOutput(command, history, start)
 		},
 	}
-}
-
-func selectCaseID(ctx context.Context, cases data.GetCasesResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(cases))
-	for i, kase := range cases {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, kase.ID, kase.Title))
-	}
-
-	idx, _, err := p.Select("Select case:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select case: %w", err)
-	}
-
-	return cases[idx].ID, nil
 }
 
 // caseHistoryCmd is the exported command registered with the root.

--- a/cmd/get/sections.go
+++ b/cmd/get/sections.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/flags"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +68,7 @@ func newSectionGetCmd(getClient func(*cobra.Command) client.ClientInterface) *co
 					return fmt.Errorf("no sections found in project %d", projectID)
 				}
 
-				sectionID, err = selectSectionID(ctx, sections)
+				sectionID, err = interactive.SelectSection(ctx, interactive.PrompterFromContext(ctx), sections, "")
 				if err != nil {
 					return err
 				}
@@ -85,21 +84,6 @@ func newSectionGetCmd(getClient func(*cobra.Command) client.ClientInterface) *co
 			return handleOutput(command, section, start)
 		},
 	}
-}
-
-func selectSectionID(ctx context.Context, sections data.GetSectionsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(sections))
-	for i, section := range sections {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, section.ID, section.Name))
-	}
-
-	idx, _, err := p.Select("Select section:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select section: %w", err)
-	}
-
-	return sections[idx].ID, nil
 }
 
 // newSectionsListCmd creates the command for listing project sections.

--- a/cmd/get/sections_test.go
+++ b/cmd/get/sections_test.go
@@ -392,13 +392,3 @@ func TestSectionsListCmd_NilClient(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP client not initialized")
 }
-
-func TestSelectSectionID_SelectError(t *testing.T) {
-	sections := data.GetSectionsResponse{{ID: 10, Name: "S-10"}}
-	ctx := interactive.WithPrompter(context.Background(), interactive.NewMockPrompter())
-
-	sectionID, err := selectSectionID(ctx, sections)
-	assert.Error(t, err)
-	assert.Equal(t, int64(0), sectionID)
-	assert.Contains(t, err.Error(), "failed to select section")
-}

--- a/cmd/get/sharedsteps.go
+++ b/cmd/get/sharedsteps.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/flags"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/spf13/cobra"
 )
 
@@ -118,7 +117,7 @@ func newSharedStepCmd(getClient func(*cobra.Command) client.ClientInterface) *co
 					return fmt.Errorf("no shared steps found in project %d", projectID)
 				}
 
-				id, err = selectSharedStepID(ctx, steps)
+				id, err = interactive.SelectSharedStep(ctx, interactive.PrompterFromContext(ctx), steps, "")
 				if err != nil {
 					return err
 				}
@@ -132,21 +131,6 @@ func newSharedStepCmd(getClient func(*cobra.Command) client.ClientInterface) *co
 			return handleOutput(command, step, start)
 		},
 	}
-}
-
-func selectSharedStepID(ctx context.Context, steps data.GetSharedStepsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(steps))
-	for i, step := range steps {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, step.ID, step.Title))
-	}
-
-	idx, _, err := p.Select("Select shared step:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select shared step: %w", err)
-	}
-
-	return steps[idx].ID, nil
 }
 
 // sharedStepsCmd is the exported command registered with the root.

--- a/cmd/groups/add.go
+++ b/cmd/groups/add.go
@@ -69,7 +69,11 @@ func newAddCmd(getClient GetClientFunc) *cobra.Command {
 
 			hook.FinalizeAdd(group.ID)
 
-			return output.OutputResult(cmd, group, "groups")
+			if err := output.OutputResult(cmd, group, "groups"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/groups/delete.go
+++ b/cmd/groups/delete.go
@@ -65,6 +65,7 @@ func newDeleteCmd(getClient GetClientFunc) *cobra.Command {
 				color.New(color.FgGreen).Fprintf(cmd.OutOrStdout(), "✓ Group %d deleted\n", groupID)
 			}
 
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/groups/interactive_helpers.go
+++ b/cmd/groups/interactive_helpers.go
@@ -36,12 +36,22 @@ func resolveGroupIDInteractive(ctx context.Context, cli client.ClientInterface) 
 // selectGroupID prompts for group selection and returns the chosen group ID.
 func selectGroupID(ctx context.Context, groups data.GetGroupsResponse) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(groups))
-	for i, group := range groups {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, group.ID, group.Name))
-	}
 
-	idx, _, err := p.Select("Select group:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(groups))
+	for i, group := range groups {
+		rows[i] = []string{fmt.Sprintf("%d", group.ID), group.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select group:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select group: %w", err)
 	}

--- a/cmd/groups/update.go
+++ b/cmd/groups/update.go
@@ -67,7 +67,11 @@ func newUpdateCmd(getClient GetClientFunc) *cobra.Command {
 				return err
 			}
 
-			return output.OutputResult(cmd, group, "groups")
+			if err := output.OutputResult(cmd, group, "groups"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/labels/interactive_helpers.go
+++ b/cmd/labels/interactive_helpers.go
@@ -38,11 +38,22 @@ func selectLabelID(ctx context.Context, labels data.GetLabelsResponse) (int64, e
 	if len(labels) == 0 {
 		return 0, fmt.Errorf("no labels found")
 	}
-	items := make([]string, len(labels))
-	for i, l := range labels {
-		items[i] = fmt.Sprintf("[%d] ID: %d | %s", i+1, l.ID, l.Name)
+
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
 	}
-	idx, _, err := p.Select("Select label:", items)
+	rows := make([][]string, len(labels))
+	for i, l := range labels {
+		rows[i] = []string{fmt.Sprintf("%d", l.ID), l.Name}
+	}
+	header, items := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select label:",
+		Header: header,
+		Items:  items,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select label: %w", err)
 	}
@@ -77,13 +88,5 @@ func selectTestID(ctx context.Context, tests []data.Test) (int64, error) {
 	if len(tests) == 0 {
 		return 0, fmt.Errorf("no tests found")
 	}
-	items := make([]string, len(tests))
-	for i, t := range tests {
-		items[i] = fmt.Sprintf("[%d] ID: %d | %s", i+1, t.ID, t.Title)
-	}
-	idx, _, err := p.Select("Select test:", items)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select test: %w", err)
-	}
-	return tests[idx].ID, nil
+	return interactive.SelectTest(ctx, p, tests, "")
 }

--- a/cmd/labels/update.go
+++ b/cmd/labels/update.go
@@ -67,6 +67,7 @@ func newUpdateTestCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✅ Labels updated for test %d: %v\n", testID, labels)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}
@@ -128,6 +129,7 @@ func newUpdateTestsCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✅ Labels updated for %d tests in run %d: %v\n", len(testIDs), runID, labels)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/labels/update_label.go
+++ b/cmd/labels/update_label.go
@@ -90,7 +90,11 @@ Maximum label name length is 20 characters.`,
 			}
 
 			_, err = output.Output(cmd, resp, "labels", "json")
-			return err
+			if err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/milestones/add.go
+++ b/cmd/milestones/add.go
@@ -98,7 +98,11 @@ Usage examples:
 			hook.FinalizeAdd(int64(resp.ID))
 
 			ui.Successf(os.Stdout, "Milestone created (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "milestones")
+			if err := output.OutputResult(cmd, resp, "milestones"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/milestones/delete.go
+++ b/cmd/milestones/delete.go
@@ -77,6 +77,7 @@ Use --dry-run to verify before deleting.`,
 			}
 
 			ui.Successf(os.Stdout, "Milestone %d deleted", milestoneID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/milestones/interactive_helpers.go
+++ b/cmd/milestones/interactive_helpers.go
@@ -33,12 +33,22 @@ func resolveMilestoneIDInteractive(ctx context.Context, cli client.ClientInterfa
 
 func selectMilestoneID(ctx context.Context, milestones []data.Milestone) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(milestones))
-	for i, m := range milestones {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, m.ID, m.Name))
-	}
 
-	idx, _, err := p.Select("Select milestone:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(milestones))
+	for i, m := range milestones {
+		rows[i] = []string{fmt.Sprintf("%d", m.ID), m.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select milestone:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select milestone: %w", err)
 	}

--- a/cmd/milestones/update.go
+++ b/cmd/milestones/update.go
@@ -98,7 +98,11 @@ All flags are optional — only specified fields will be changed.`,
 			}
 
 			ui.Successf(os.Stdout, "Milestone %d updated", milestoneID)
-			return output.OutputResult(cmd, resp, "milestones")
+			if err := output.OutputResult(cmd, resp, "milestones"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/plans/add.go
+++ b/cmd/plans/add.go
@@ -93,7 +93,11 @@ func newAddCmd(getClient GetClientFunc) *cobra.Command {
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Plan created (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "plans")
+			if err := output.OutputResult(cmd, resp, "plans"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/plans/close.go
+++ b/cmd/plans/close.go
@@ -76,7 +76,11 @@ func newCloseCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Plan %d closed", planID)
-			return output.OutputResult(cmd, resp, "plans")
+			if err := output.OutputResult(cmd, resp, "plans"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/plans/delete.go
+++ b/cmd/plans/delete.go
@@ -75,6 +75,7 @@ func newDeleteCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Plan %d deleted", planID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/plans/entry.go
+++ b/cmd/plans/entry.go
@@ -115,7 +115,11 @@ func newEntryAddCmd(getClient GetClientFunc) *cobra.Command {
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Entry added to plan %d", planID)
-			return output.OutputResult(cmd, resp, "plans")
+			if err := output.OutputResult(cmd, resp, "plans"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 
@@ -209,7 +213,11 @@ func newEntryUpdateCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Entry %s updated in plan %d", entryID, planID)
-			return output.OutputResult(cmd, resp, "plans")
+			if err := output.OutputResult(cmd, resp, "plans"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 
@@ -298,6 +306,7 @@ func newEntryDeleteCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Entry %s deleted from plan %d", entryID, planID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/plans/interactive_helpers.go
+++ b/cmd/plans/interactive_helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Korrnals/gotr/internal/client"
 	"github.com/Korrnals/gotr/internal/interactive"
-	"github.com/Korrnals/gotr/internal/models/data"
 )
 
 func resolveProjectIDInteractive(ctx context.Context, cli client.ClientInterface) (int64, error) {
@@ -28,22 +27,8 @@ func resolvePlanIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no plans found in project %d", projectID)
 	}
 
-	return selectPlanID(ctx, plans)
-}
-
-func selectPlanID(ctx context.Context, plans []data.Plan) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(plans))
-	for i, plan := range plans {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, plan.ID, plan.Name))
-	}
-
-	idx, _, err := p.Select("Select plan:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select plan: %w", err)
-	}
-
-	return plans[idx].ID, nil
+	return interactive.SelectPlan(ctx, p, plans, "")
 }
 
 func resolvePlanEntryIDInteractive(ctx context.Context, cli client.ClientInterface, planID int64) (string, error) {
@@ -56,15 +41,5 @@ func resolvePlanEntryIDInteractive(ctx context.Context, cli client.ClientInterfa
 	}
 
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(plan.Entries))
-	for i, entry := range plan.Entries {
-		options = append(options, fmt.Sprintf("[%d] ID: %s | %s", i+1, entry.ID, entry.Name))
-	}
-
-	idx, _, err := p.Select("Select plan entry:", options)
-	if err != nil {
-		return "", fmt.Errorf("failed to select plan entry: %w", err)
-	}
-
-	return plan.Entries[idx].ID, nil
+	return interactive.SelectPlanEntry(ctx, p, plan.Entries, "")
 }

--- a/cmd/plans/update.go
+++ b/cmd/plans/update.go
@@ -88,7 +88,11 @@ func newUpdateCmd(getClient GetClientFunc) *cobra.Command {
 			}
 
 			ui.Successf(os.Stdout, "Plan %d updated", planID)
-			return output.OutputResult(cmd, resp, "plans")
+			if err := output.OutputResult(cmd, resp, "plans"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/reports/interactive_helpers.go
+++ b/cmd/reports/interactive_helpers.go
@@ -45,12 +45,22 @@ func resolveCrossProjectReportTemplateIDInteractive(ctx context.Context, cli cli
 
 func selectReportTemplateID(ctx context.Context, reports data.GetReportsResponse) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(reports))
-	for i, r := range reports {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, r.ID, r.Name))
-	}
 
-	idx, _, err := p.Select("Select report template:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(reports))
+	for i, r := range reports {
+		rows[i] = []string{fmt.Sprintf("%d", r.ID), r.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select report template:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select report template: %w", err)
 	}

--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -55,6 +55,9 @@ type contextKey string
 // httpClientKey is used to store/retrieve the HTTP client from context.
 const httpClientKey contextKey = "httpClient"
 
+// serverURLKey is used to store/retrieve the base server URL from context.
+const serverURLKey contextKey = "serverURL"
+
 // ValidResources is a dynamically generated list of all resource names.
 var ValidResources []string
 

--- a/cmd/result/add.go
+++ b/cmd/result/add.go
@@ -114,7 +114,11 @@ Examples:
 			}
 
 			output.PrintSuccess(cmd, "Result added successfully:")
-			return output.OutputResultWithFlags(cmd, result)
+			if err := output.OutputResultWithFlags(cmd, result); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 
@@ -216,7 +220,11 @@ Examples:
 			}
 
 			output.PrintSuccess(cmd, "Result added successfully:")
-			return output.OutputResultWithFlags(cmd, result)
+			if err := output.OutputResultWithFlags(cmd, result); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 
@@ -306,7 +314,11 @@ Examples:
 			}
 
 			output.PrintSuccess(cmd, "Results added successfully:")
-			return output.OutputResultWithFlags(cmd, results)
+			if err := output.OutputResultWithFlags(cmd, results); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/result/get.go
+++ b/cmd/result/get.go
@@ -182,12 +182,23 @@ func selectTestIDForRun(ctx context.Context, cli client.ClientInterface, runID i
 	}
 
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(tests))
-	for i, test := range tests {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | Case: %d | %s", i+1, test.ID, test.CaseID, test.Title))
-	}
 
-	idx, _, err := p.Select("Select test:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Case", MinWidth: 6},
+		{Header: "Title"},
+	}
+	rows := make([][]string, len(tests))
+	for i, test := range tests {
+		rows[i] = []string{fmt.Sprintf("%d", test.ID), fmt.Sprintf("%d", test.CaseID), test.Title}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select test:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select test: %w", err)
 	}
@@ -218,13 +229,24 @@ func selectCaseIDForRun(ctx context.Context, cli client.ClientInterface, runID i
 	sort.Slice(caseIDs, func(i, j int) bool { return caseIDs[i] < caseIDs[j] })
 
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(caseIDs))
+
+	cols := []interactive.Column{
+		{Header: "Case", MinWidth: 6},
+		{Header: "Test", MinWidth: 6},
+		{Header: "Title"},
+	}
+	rows := make([][]string, len(caseIDs))
 	for i, caseID := range caseIDs {
 		test := byCase[caseID]
-		options = append(options, fmt.Sprintf("[%d] Case: %d | Test: %d | %s", i+1, caseID, test.ID, test.Title))
+		rows[i] = []string{fmt.Sprintf("%d", caseID), fmt.Sprintf("%d", test.ID), test.Title}
 	}
+	header, options := interactive.AlignedLabels(cols, rows)
 
-	idx, _, err := p.Select("Select case:", options)
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select case:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select case: %w", err)
 	}

--- a/cmd/roles/interactive_helpers.go
+++ b/cmd/roles/interactive_helpers.go
@@ -17,11 +17,22 @@ func resolveRoleIDInteractive(ctx context.Context, cli client.ClientInterface) (
 	if len(roles) == 0 {
 		return 0, fmt.Errorf("no roles found")
 	}
-	items := make([]string, len(roles))
-	for i, role := range roles {
-		items[i] = fmt.Sprintf("[%d] ID: %d | %s", i+1, role.ID, role.Name)
+
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
 	}
-	idx, _, err := p.Select("Select role:", items)
+	rows := make([][]string, len(roles))
+	for i, role := range roles {
+		rows[i] = []string{fmt.Sprintf("%d", role.ID), role.Name}
+	}
+	header, items := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select role:",
+		Header: header,
+		Items:  items,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select role: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,10 @@ func Execute(ctx context.Context) {
 			fmt.Fprintln(os.Stderr, "\nInterrupted.")
 			os.Exit(130)
 		}
+		// Silent exit from interactive navigation (Back/Exit).
+		if interactive.IsGoBack(err) || interactive.IsExit(err) {
+			return
+		}
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,9 @@ Supports browsing available endpoints, executing requests, and more.`,
 		// Store the client in context so it is available in all subcommands
 		ctx := context.WithValue(cmd.Context(), httpClientKey, httpClient)
 
+		// Store the server URL in context for easy access by any command.
+		ctx = context.WithValue(ctx, serverURLKey, baseURL)
+
 		// Inject Prompter into context (TerminalPrompter or NonInteractivePrompter)
 		nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
 		var p interactive.Prompter
@@ -95,6 +98,11 @@ Supports browsing available endpoints, executing requests, and more.`,
 			p = interactive.NewTerminalPrompter()
 		}
 		ctx = interactive.WithPrompter(ctx, p)
+
+		// Show server URL banner in interactive mode.
+		if !nonInteractive {
+			ui.Infof(os.Stderr, "Server: %s", baseURL)
+		}
 
 		cmd.SetContext(ctx)
 
@@ -145,6 +153,18 @@ func GetClientFromCtx(ctx context.Context) client.ClientInterface {
 		return nil // unreachable
 	}
 	return cli
+}
+
+// GetServerURL retrieves the configured server URL from the command context.
+func GetServerURL(cmd *cobra.Command) string {
+	return GetServerURLFromCtx(cmd.Context())
+}
+
+// GetServerURLFromCtx retrieves the configured server URL from a context.
+// Returns an empty string if the value is not set.
+func GetServerURLFromCtx(ctx context.Context) string {
+	s, _ := ctx.Value(serverURLKey).(string)
+	return s
 }
 
 func initConfig() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -461,3 +461,37 @@ func TestInitConfig_ReadsConfigFromCurrentDirWhenHomeHasNoConfig(t *testing.T) {
 	initConfig()
 	assert.Equal(t, wdConfig, viper.ConfigFileUsed())
 }
+
+func TestGetServerURL_Success(t *testing.T) {
+	cmd := &cobra.Command{}
+	ctx := context.WithValue(context.Background(), serverURLKey, "https://example.testrail.io")
+	cmd.SetContext(ctx)
+
+	got := GetServerURL(cmd)
+	assert.Equal(t, "https://example.testrail.io", got)
+}
+
+func TestGetServerURLFromCtx_Empty(t *testing.T) {
+	got := GetServerURLFromCtx(context.Background())
+	assert.Equal(t, "", got)
+}
+
+func TestRootPersistentPreRunE_SetsServerURL(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("base_url", "https://example.com")
+	viper.Set("username", "qa@example.com")
+	viper.Set("api_key", "api-key")
+
+	cmd := &cobra.Command{Use: "test-cmd"}
+	cmd.Flags().Bool("quiet", false, "")
+	cmd.Flags().Bool("non-interactive", false, "")
+	require.NoError(t, cmd.Flags().Set("non-interactive", "true"))
+	cmd.SetContext(context.Background())
+
+	err := rootCmd.PersistentPreRunE(cmd, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://example.com", GetServerURLFromCtx(cmd.Context()))
+}

--- a/cmd/run/close.go
+++ b/cmd/run/close.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Korrnals/gotr/internal/client"
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/snap"
@@ -85,7 +86,11 @@ Examples:
 			}
 
 			output.PrintSuccess(cmd, "Test run closed successfully:")
-			return output.OutputResultWithFlags(cmd, run)
+			if err := output.OutputResultWithFlags(cmd, run); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/run/create.go
+++ b/cmd/run/create.go
@@ -138,7 +138,11 @@ Examples:
 			hook.FinalizeAdd(run.ID)
 
 			output.PrintSuccess(cmd, "Test run created successfully (ID: %d):", run.ID)
-			return output.OutputResultWithFlags(cmd, run)
+			if err := output.OutputResultWithFlags(cmd, run); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/run/delete.go
+++ b/cmd/run/delete.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Korrnals/gotr/internal/client"
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/service"
@@ -135,6 +136,7 @@ Examples:
 			}
 
 			output.PrintSuccess(cmd, "Test run %d deleted successfully", runID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/run/update.go
+++ b/cmd/run/update.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Korrnals/gotr/internal/client"
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/snap"
@@ -111,7 +112,11 @@ Examples:
 			}
 
 			output.PrintSuccess(cmd, "Test run updated successfully:")
-			return output.OutputResultWithFlags(cmd, run)
+			if err := output.OutputResultWithFlags(cmd, run); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/snap/info.go
+++ b/cmd/snap/info.go
@@ -84,6 +84,14 @@ func humanSize(b int64) string {
 	}
 }
 
+// formatInfoProject returns a formatted ID or "–" for zero values.
+func formatInfoProject(id int64) string {
+	if id == 0 {
+		return "–"
+	}
+	return fmt.Sprintf("%d", id)
+}
+
 // renderInfoCard prints a structured snapshot info card.
 func renderInfoCard(cmd *cobra.Command, meta *snaplib.Meta) {
 	out := cmd.OutOrStdout()
@@ -108,8 +116,9 @@ func renderInfoCard(cmd *cobra.Command, meta *snaplib.Meta) {
 		{"Tier", tierLabel(meta.RollbackTier)},
 		{"Status", meta.Status},
 		{"Entity IDs", entityIDs},
-		{"Project", meta.ProjectID},
-		{"Suite", meta.SuiteID},
+		{"Project", formatInfoProject(meta.ProjectID)},
+		{"Source Project", formatInfoProject(meta.SourceProjectID)},
+		{"Suite", formatInfoProject(meta.SuiteID)},
 		{"CLI Command", meta.CLICommand},
 		{"Created", meta.Timestamp.Format("2006-01-02 15:04:05 UTC")},
 		{"Data Size", humanSize(meta.DataSizeBytes)},

--- a/cmd/snap/interactive_helpers.go
+++ b/cmd/snap/interactive_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Korrnals/gotr/internal/interactive"
 	snaplib "github.com/Korrnals/gotr/internal/snap"
+	"github.com/Korrnals/gotr/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -56,6 +57,21 @@ func entityIDsLabel(ids []int64) string {
 	return fmt.Sprintf(" #%d,…(+%d)", ids[0], len(ids)-1)
 }
 
+// projectLabel formats source → destination project IDs for display.
+// Returns "–" when no project info is available (legacy snapshots).
+func projectLabel(srcProjectID, dstProjectID int64) string {
+	if srcProjectID > 0 && dstProjectID > 0 {
+		return fmt.Sprintf("P%d → P%d", srcProjectID, dstProjectID)
+	}
+	if dstProjectID > 0 {
+		return fmt.Sprintf("P%d", dstProjectID)
+	}
+	if srcProjectID > 0 {
+		return fmt.Sprintf("P%d", srcProjectID)
+	}
+	return "–"
+}
+
 // isInterruptError returns true if the error is caused by user pressing Ctrl+C.
 func isInterruptError(err error) bool {
 	if err == nil {
@@ -93,6 +109,11 @@ func formatPickerLabel(idx int, e snaplib.ManifestEntry) string {
 	fmt.Fprintf(&b, "[%d] %s %s", idx, e.Operation, e.EntityType)
 	b.WriteString(entityIDsLabel(e.EntityIDs))
 
+	proj := projectLabel(e.SourceProjectID, e.ProjectID)
+	if proj != "–" {
+		fmt.Fprintf(&b, " (%s)", proj)
+	}
+
 	if e.Name != "" {
 		fmt.Fprintf(&b, " %q", e.Name)
 	}
@@ -112,6 +133,7 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 		idx      string
 		opEntity string
 		ids      string
+		project  string
 		cat      string
 		name     string
 		label    string
@@ -122,10 +144,10 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 	}
 
 	rows := make([]row, len(entries))
-	maxIdx, maxOp, maxIDs, maxCat, maxName, maxLabel, maxStatus, maxTier, maxTs, maxSnap := 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	maxIdx, maxOp, maxIDs, maxProj, maxCat, maxName, maxLabel, maxStatus, maxTier, maxTs, maxSnap := 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 	// Header widths.
-	hIdx, hOp, hIDs, hCat, hName := "#", "OPERATION", "IDS", "CATEGORY", ""
+	hIdx, hOp, hIDs, hProj, hCat, hName := "#", "OPERATION", "IDS", "PROJECT", "CATEGORY", ""
 	hLabel := ""
 	hStatus, hTier, hTs, hSnap := "STATUS", "TIER", "DATE", "SNAPSHOT ID"
 
@@ -138,6 +160,7 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 			idx:      fmt.Sprintf("[%d]", i+1),
 			opEntity: fmt.Sprintf("%s %s", e.Operation, e.EntityType),
 			ids:      idsLabel,
+			project:  projectLabel(e.SourceProjectID, e.ProjectID),
 			cat:      string(e.Category),
 			status:   string(e.Status),
 			tier:     fmt.Sprintf("T%d", e.RollbackTier),
@@ -155,6 +178,7 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 		if len(r.idx) > maxIdx { maxIdx = len(r.idx) }
 		if len(r.opEntity) > maxOp { maxOp = len(r.opEntity) }
 		if len(r.ids) > maxIDs { maxIDs = len(r.ids) }
+		if len(r.project) > maxProj { maxProj = len(r.project) }
 		if len(r.cat) > maxCat { maxCat = len(r.cat) }
 		if len(r.name) > maxName { maxName = len(r.name) }
 		if len(r.label) > maxLabel { maxLabel = len(r.label) }
@@ -168,6 +192,7 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 	if len(hIdx) > maxIdx { maxIdx = len(hIdx) }
 	if len(hOp) > maxOp { maxOp = len(hOp) }
 	if len(hIDs) > maxIDs { maxIDs = len(hIDs) }
+	if len(hProj) > maxProj { maxProj = len(hProj) }
 	if len(hCat) > maxCat { maxCat = len(hCat) }
 	if len(hLabel) > maxLabel { maxLabel = len(hLabel) }
 	if len(hStatus) > maxStatus { maxStatus = len(hStatus) }
@@ -176,10 +201,14 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 	if len(hSnap) > maxSnap { maxSnap = len(hSnap) }
 
 	// Build format function — all columns separated by │.
-	fmtRow := func(idx, op, ids, cat, name, label, status, tier, ts, snap string) string {
+	fmtRow := func(idx, op, ids, proj, cat, name, label, status, tier, ts, snap string) string {
 		var b strings.Builder
-		fmt.Fprintf(&b, "%-*s %-*s │ %-*s │ %-*s",
-			maxIdx, idx, maxOp, op, maxIDs, ids, maxCat, cat)
+		fmt.Fprintf(&b, "%-*s %-*s │ %-*s",
+			maxIdx, idx, maxOp, op, maxIDs, ids)
+		if maxProj > 0 {
+			fmt.Fprintf(&b, " │ %-*s", maxProj, proj)
+		}
+		fmt.Fprintf(&b, " │ %-*s", maxCat, cat)
 		if maxName > 0 {
 			fmt.Fprintf(&b, " │ %-*s", maxName, name)
 		}
@@ -192,12 +221,12 @@ func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels
 	}
 
 	// Header.
-	header = fmtRow(hIdx, hOp, hIDs, hCat, hName, hLabel, hStatus, hTier, hTs, hSnap)
+	header = fmtRow(hIdx, hOp, hIDs, hProj, hCat, hName, hLabel, hStatus, hTier, hTs, hSnap)
 
 	// Data rows.
 	labels = make([]string, len(entries))
 	for i, r := range rows {
-		labels[i] = fmtRow(r.idx, r.opEntity, r.ids, r.cat, r.name, r.label, r.status, r.tier, r.ts, r.snapID)
+		labels[i] = fmtRow(r.idx, r.opEntity, r.ids, r.project, r.cat, r.name, r.label, r.status, r.tier, r.ts, r.snapID)
 	}
 	return header, labels
 }
@@ -712,6 +741,12 @@ func browseSnapList(cmd *cobra.Command, store *snaplib.Store, p interactive.Prom
 		case postActionRollback:
 			executeRollbackFromBrowser(cmd, entry.ID)
 			continue // back to snapshot list after rollback
+		case postActionCompare:
+			runCompareFromSnap(cmd)
+			continue
+		case postActionSync:
+			runSyncFromSnap(cmd)
+			continue
 		}
 	}
 }
@@ -726,40 +761,73 @@ const (
 	postActionBack postAction = iota
 	postActionExit
 	postActionRollback
+	postActionCompare
+	postActionSync
 )
 
 // postCardAction shows a mini-menu after viewing a snapshot info card.
 // Returns the chosen action.
 func postCardAction(cmd *cobra.Command, p interactive.Prompter, meta *snaplib.Meta) (postAction, error) {
 	out := cmd.OutOrStdout()
-	options := []string{backOption, exitOption}
 
-	// Show rollback option only for actionable statuses;
-	// for terminal statuses print a hint instead.
+	type menuItem struct {
+		label  string
+		action postAction
+	}
+	items := []menuItem{
+		{backOption, postActionBack},
+		{exitOption, postActionExit},
+	}
+
+	// Rollback option — only for actionable statuses.
 	canRollback := meta.Status == snaplib.StatusAvailable || meta.Status == snaplib.StatusRollbackPartial
 	if canRollback {
-		options = append(options, "↻ Rollback this snapshot")
+		items = append(items, menuItem{"↻ Rollback this snapshot", postActionRollback})
 	} else if meta.Status == snaplib.StatusRolledBack {
 		fmt.Fprintln(out, "  ✓ Snapshot already rolled back.")
 	} else if meta.Status == snaplib.StatusExpired {
 		fmt.Fprintln(out, "  ⚠ Snapshot expired — rollback unavailable.")
 	}
 
+	// Cross-navigation transitions (full navigation level).
+	items = append(items,
+		menuItem{"📊 Compare: verify current state", postActionCompare},
+		menuItem{"🔄 Sync: migrate data", postActionSync},
+	)
+
+	options := make([]string, len(items))
+	for i, it := range items {
+		options[i] = it.label
+	}
+
 	idx, _, err := p.Select("Action:", options)
 	if err != nil {
 		return postActionExit, err
 	}
-
-	switch idx {
-	case 0:
-		return postActionBack, nil
-	case 1:
-		return postActionExit, nil
-	case 2:
-		return postActionRollback, nil
-	default:
-		return postActionBack, nil
+	if idx >= 0 && idx < len(items) {
+		return items[idx].action, nil
 	}
+	return postActionBack, nil
+}
+
+// runCompareFromSnap launches compare all from the snap browser.
+func runCompareFromSnap(cmd *cobra.Command) {
+	ctx := cmd.Context()
+	fmt.Println()
+	if err := interactive.RunSubcommand(ctx, cmd.Root(), "compare", "all"); err != nil {
+		ui.Error(cmd.OutOrStdout(), err.Error())
+	}
+	fmt.Println()
+}
+
+// runSyncFromSnap launches the sync hub from the snap browser.
+func runSyncFromSnap(cmd *cobra.Command) {
+	ctx := cmd.Context()
+	fmt.Println()
+	if err := interactive.RunSubcommand(ctx, cmd.Root(), "sync", "full"); err != nil {
+		ui.Error(cmd.OutOrStdout(), err.Error())
+	}
+	fmt.Println()
 }
 
 // executeRollbackFromBrowser finds and runs the rollback subcommand for the given snapshot.

--- a/cmd/snap/interactive_helpers.go
+++ b/cmd/snap/interactive_helpers.go
@@ -728,27 +728,21 @@ func browseSnapList(cmd *cobra.Command, store *snaplib.Store, p interactive.Prom
 		fmt.Fprintln(cmd.OutOrStdout())
 
 		// Post-card action menu.
-		action, err := postCardAction(cmd, p, meta)
+		key, err := postCardAction(cmd, p, meta)
 		if err != nil {
 			return errExit
 		}
-		switch action {
-		case postActionBack:
+		switch key {
+		case "back":
 			continue // back to snapshot list
-		case postActionExit:
+		case "exit":
 			return errExit
-		case postActionRollback:
+		case "rollback":
 			executeRollbackFromBrowser(cmd, entry.ID)
 			continue // back to snapshot list after rollback
-		case postActionCompare:
-			if err := interactive.RunSubcommand(cmd.Context(), cmd.Root(), "compare", "all"); err != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Compare failed: %v\n", err)
-			}
-			continue
-		case postActionSync:
-			if err := interactive.RunSubcommand(cmd.Context(), cmd.Root(), "sync", "full"); err != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Sync failed: %v\n", err)
-			}
+		default:
+			// Cross-navigation keys (nav:compare, nav:sync, nav:snap).
+			interactive.HandleCrossNav(cmd.Context(), cmd, key)
 			continue
 		}
 	}
@@ -758,59 +752,50 @@ func browseSnapList(cmd *cobra.Command, store *snaplib.Store, p interactive.Prom
 // Post-card action menu
 // ---------------------------------------------------------------------------
 
+// postAction is a local enum used by undo.go for its simpler card menus.
 type postAction int
 
 const (
 	postActionBack postAction = iota
 	postActionExit
 	postActionRollback
-	postActionCompare
-	postActionSync
 )
 
 // postCardAction shows a mini-menu after viewing a snapshot info card.
-// Returns the chosen action.
-func postCardAction(cmd *cobra.Command, p interactive.Prompter, meta *snaplib.Meta) (postAction, error) {
+// Returns the chosen action key.
+func postCardAction(cmd *cobra.Command, p interactive.Prompter, meta *snaplib.Meta) (string, error) {
 	out := cmd.OutOrStdout()
+	ctx := cmd.Context()
 
-	type menuItem struct {
-		label  string
-		action postAction
-	}
-	items := []menuItem{
-		{backOption, postActionBack},
-		{exitOption, postActionExit},
+	const (
+		keyBack     = "back"
+		keyExit     = "exit"
+		keyRollback = "rollback"
+	)
+
+	options := []interactive.ActionOption{
+		{Label: backOption, Key: keyBack},
+		{Label: exitOption, Key: keyExit},
 	}
 
 	// Rollback option — only for actionable statuses.
 	canRollback := meta.Status == snaplib.StatusAvailable || meta.Status == snaplib.StatusRollbackPartial
 	if canRollback {
-		items = append(items, menuItem{"↻ Rollback this snapshot", postActionRollback})
+		options = append(options, interactive.ActionOption{Label: "↻ Rollback this snapshot", Key: keyRollback})
 	} else if meta.Status == snaplib.StatusRolledBack {
 		fmt.Fprintln(out, "  ✓ Snapshot already rolled back.")
 	} else if meta.Status == snaplib.StatusExpired {
 		fmt.Fprintln(out, "  ⚠ Snapshot expired — rollback unavailable.")
 	}
 
-	// Cross-navigation transitions (full navigation level).
-	items = append(items,
-		menuItem{"📊 Compare: verify current state", postActionCompare},
-		menuItem{"🔄 Sync: migrate data", postActionSync},
-	)
+	// Cross-navigation transitions.
+	options = append(options, interactive.CrossNavOptions()...)
 
-	options := make([]string, len(items))
-	for i, it := range items {
-		options[i] = it.label
-	}
-
-	idx, _, err := p.Select("Action:", options)
+	key, err := interactive.ActionMenu(ctx, p, "Action:", options)
 	if err != nil {
-		return postActionExit, err
+		return keyExit, err
 	}
-	if idx >= 0 && idx < len(items) {
-		return items[idx].action, nil
-	}
-	return postActionBack, nil
+	return key, nil
 }
 
 // executeRollbackFromBrowser finds and runs the rollback subcommand for the given snapshot.

--- a/cmd/snap/interactive_helpers.go
+++ b/cmd/snap/interactive_helpers.go
@@ -2,6 +2,7 @@ package snap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -19,10 +20,10 @@ const backOption = "← Back"
 const exitOption = "✕ Exit"
 
 // errGoBack is a sentinel to signal user chose "← Back".
-var errGoBack = fmt.Errorf("go back")
+var errGoBack = errors.New("go back")
 
 // errExit is a sentinel to signal user chose "✕ Exit".
-var errExit = fmt.Errorf("exit")
+var errExit = errors.New("exit")
 
 // serverLabel returns a normalised display string for a server URL.
 // Strips API path, shows only scheme+host. Empty → "(legacy)" for old snapshots.
@@ -127,6 +128,7 @@ func formatPickerLabel(idx int, e snaplib.ManifestEntry) string {
 
 // alignedPickerLabels returns picker labels with consistent column widths.
 // Includes a header row as the first element.
+//nolint:gocyclo // Width calculation and column formatting are intentionally explicit.
 func alignedPickerLabels(entries []snaplib.ManifestEntry) (header string, labels []string) {
 	type row struct {
 		idx      string
@@ -288,7 +290,7 @@ func groupByCategory(entries []snaplib.ManifestEntry) []categoryGroup {
 // Three-level picker: server → operation → snapshot
 // ---------------------------------------------------------------------------
 
-// pickerOpts configures selectSnapshot behaviour.
+// pickerOpts configures selectSnapshot behavior.
 type pickerOpts struct {
 	// statusFilter limits which statuses are selectable (nil = all).
 	statusFilter []snaplib.Status
@@ -567,6 +569,7 @@ func browseSnapshots(cmd *cobra.Command, store *snaplib.Store, manifest *snaplib
 }
 
 // browseByOperation shows operation picker, then delegates to browseSnapList.
+//nolint:gocyclo // Interactive operation browsing keeps back/exit handling explicit.
 func browseByOperation(cmd *cobra.Command, store *snaplib.Store, p interactive.Prompter, entries []snaplib.ManifestEntry, allowBack bool) error {
 	opGroups := groupByOperation(entries)
 

--- a/cmd/snap/interactive_helpers.go
+++ b/cmd/snap/interactive_helpers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Korrnals/gotr/internal/interactive"
 	snaplib "github.com/Korrnals/gotr/internal/snap"
-	"github.com/Korrnals/gotr/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -742,10 +741,14 @@ func browseSnapList(cmd *cobra.Command, store *snaplib.Store, p interactive.Prom
 			executeRollbackFromBrowser(cmd, entry.ID)
 			continue // back to snapshot list after rollback
 		case postActionCompare:
-			runCompareFromSnap(cmd)
+			if err := interactive.RunSubcommand(cmd.Context(), cmd.Root(), "compare", "all"); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Compare failed: %v\n", err)
+			}
 			continue
 		case postActionSync:
-			runSyncFromSnap(cmd)
+			if err := interactive.RunSubcommand(cmd.Context(), cmd.Root(), "sync", "full"); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Sync failed: %v\n", err)
+			}
 			continue
 		}
 	}
@@ -808,26 +811,6 @@ func postCardAction(cmd *cobra.Command, p interactive.Prompter, meta *snaplib.Me
 		return items[idx].action, nil
 	}
 	return postActionBack, nil
-}
-
-// runCompareFromSnap launches compare all from the snap browser.
-func runCompareFromSnap(cmd *cobra.Command) {
-	ctx := cmd.Context()
-	fmt.Println()
-	if err := interactive.RunSubcommand(ctx, cmd.Root(), "compare", "all"); err != nil {
-		ui.Error(cmd.OutOrStdout(), err.Error())
-	}
-	fmt.Println()
-}
-
-// runSyncFromSnap launches the sync hub from the snap browser.
-func runSyncFromSnap(cmd *cobra.Command) {
-	ctx := cmd.Context()
-	fmt.Println()
-	if err := interactive.RunSubcommand(ctx, cmd.Root(), "sync", "full"); err != nil {
-		ui.Error(cmd.OutOrStdout(), err.Error())
-	}
-	fmt.Println()
 }
 
 // executeRollbackFromBrowser finds and runs the rollback subcommand for the given snapshot.

--- a/cmd/snap/list.go
+++ b/cmd/snap/list.go
@@ -93,11 +93,12 @@ func listTable(cmd *cobra.Command, entries []snaplib.ManifestEntry) error {
 	}
 
 	t := ui.NewTable(cmd)
-	t.AppendHeader(table.Row{"#", "ID", "SERVER", "OP", "ENTITY", "IDS", "CATEGORY", "LABEL", "STATUS", "TIMESTAMP"})
+	t.AppendHeader(table.Row{"#", "ID", "SERVER", "OP", "ENTITY", "IDS", "PROJECT", "CATEGORY", "LABEL", "STATUS", "TIMESTAMP"})
 	for i, e := range entries {
 		t.AppendRow(table.Row{
 			i + 1, e.ID, serverLabel(e.ServerURL),
 			e.Operation, e.EntityType, entityIDsLabel(e.EntityIDs),
+			projectLabel(e.SourceProjectID, e.ProjectID),
 			e.Category, e.Label, e.Status,
 			e.Timestamp.Format("2006-01-02 15:04:05"),
 		})

--- a/cmd/snap/rollback.go
+++ b/cmd/snap/rollback.go
@@ -42,19 +42,19 @@ Subcommands:
 
 			store, err := snaplib.NewStore()
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackCmd.func: %w", err)
 			}
 
 			manifest, err := snaplib.LoadManifest(store)
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackCmd.func: %w", err)
 			}
 
 			snapID, err := resolveSnapshotIDWith(ctx, args, manifest, "Select snapshot to rollback:", &pickerOpts{
 				statusFilter: []snaplib.Status{snaplib.StatusAvailable, snaplib.StatusRollbackPartial},
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackCmd.func: %w", err)
 			}
 
 			entry := manifest.Find(snapID)
@@ -104,7 +104,7 @@ Subcommands:
 						return wrapInterrupt(err)
 					}
 					if !confirmed {
-						fmt.Fprintln(os.Stdout, "Rollback cancelled.")
+						fmt.Fprintln(os.Stdout, "Rollback canceled.")
 						return nil
 					}
 				}

--- a/cmd/snap/smoke_test.go
+++ b/cmd/snap/smoke_test.go
@@ -67,17 +67,6 @@ func seedSnapshot(t *testing.T, op snaplib.Operation, entityType string, entityI
 	return store, manifest, snap.Meta.ID
 }
 
-// execCmd builds a cobra command, sets args, captures stdout, executes.
-func execCmd(t *testing.T, cmd *cobra.Command, args []string) (string, error) {
-	t.Helper()
-	buf := &bytes.Buffer{}
-	cmd.SetOut(buf)
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs(args)
-	err := cmd.Execute()
-	return buf.String(), err
-}
-
 // ---------------------------------------------------------------------------
 // CLI Smoke: snap list
 // ---------------------------------------------------------------------------

--- a/cmd/snap/smoke_test.go
+++ b/cmd/snap/smoke_test.go
@@ -542,7 +542,7 @@ func TestCLI_SnapInfo_Interactive(t *testing.T) {
 	// Options: ✕ Exit(0), [1] snapshot(1). Select index 1 to view card.
 	// On next loop iteration mock exhausts → graceful exit.
 	mp := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 1})
+		WithSelectResponses(interactive.SelectResponse{Index: 1, Raw: true})
 
 	cmd := newInfoCmd()
 	buf := &bytes.Buffer{}
@@ -817,8 +817,8 @@ func TestCLI_SnapList_Interactive_MultiServer(t *testing.T) {
 	// After viewing card, mock exhausts → graceful exit.
 	mp := interactive.NewMockPrompter().
 		WithSelectResponses(
-			interactive.SelectResponse{Index: 1},
-			interactive.SelectResponse{Index: 2},
+			interactive.SelectResponse{Index: 1, Raw: true},
+			interactive.SelectResponse{Index: 2, Raw: true},
 		)
 
 	cmd := newListCmd()
@@ -1146,8 +1146,8 @@ func TestCLI_SnapInfo_Interactive_BackAfterCard(t *testing.T) {
 	// Mock then exhausts on next snapshot picker → graceful exit.
 	mp := interactive.NewMockPrompter().
 		WithSelectResponses(
-			interactive.SelectResponse{Index: 1}, // pick snapshot
-			interactive.SelectResponse{Index: 0}, // ← Back (post-card)
+			interactive.SelectResponse{Index: 1, Raw: true}, // pick snapshot
+			interactive.SelectResponse{Index: 0, Raw: true}, // ← Back (post-card)
 		)
 
 	cmd := newInfoCmd()

--- a/cmd/snap/undo.go
+++ b/cmd/snap/undo.go
@@ -27,12 +27,12 @@ From the snapshot card you can undo the rollback (delete re-created entities).`,
 
 			store, err := snaplib.NewStore()
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackListCmd.func: %w", err)
 			}
 
 			manifest, err := snaplib.LoadManifest(store)
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackListCmd.func: %w", err)
 			}
 
 			return browseUndoSnapshots(cmd, api, store, manifest)
@@ -67,12 +67,12 @@ If snapshot_id is omitted, shows an interactive picker with only rolled-back sna
 
 			store, err := snaplib.NewStore()
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackUndoCmd.func: %w", err)
 			}
 
 			manifest, err := snaplib.LoadManifest(store)
 			if err != nil {
-				return err
+				return fmt.Errorf("newRollbackUndoCmd.func: %w", err)
 			}
 
 			// Non-interactive or explicit ID: undo directly.
@@ -81,7 +81,7 @@ If snapshot_id is omitted, shows an interactive picker with only rolled-back sna
 					statusFilter: []snaplib.Status{snaplib.StatusRolledBack},
 				})
 				if err != nil {
-					return err
+					return fmt.Errorf("newRollbackUndoCmd.func: %w", err)
 				}
 				return executeUndo(cmd, api, store, manifest, snapID)
 			}
@@ -144,6 +144,7 @@ func browseUndoSnapshots(cmd *cobra.Command, api snaplib.RollbackAPI, store *sna
 }
 
 // browseUndoList shows the snapshot picker → card → undo menu for rolled-back snapshots.
+//nolint:gocyclo // Interactive browser flow keeps explicit menu transitions.
 func browseUndoList(cmd *cobra.Command, api snaplib.RollbackAPI, store *snaplib.Store, manifest *snaplib.Manifest, p interactive.Prompter, entries []snaplib.ManifestEntry, allowBack bool) error {
 	labels := undoPickerLabels(store, entries)
 
@@ -285,7 +286,7 @@ func executeUndoFromBrowser(cmd *cobra.Command, api snaplib.RollbackAPI, store *
 	p := interactive.PrompterFromContext(cmd.Context())
 	confirmed, err := p.Confirm("Undo this rollback? Re-created entities will be deleted.", false)
 	if err != nil || !confirmed {
-		fmt.Fprintln(cmd.OutOrStdout(), "  Cancelled.")
+		fmt.Fprintln(cmd.OutOrStdout(), "  Canceled.")
 		return
 	}
 
@@ -333,7 +334,7 @@ func executeUndo(cmd *cobra.Command, api snaplib.RollbackAPI, store *snaplib.Sto
 			return wrapInterrupt(err)
 		}
 		if !confirmed {
-			fmt.Fprintln(cmd.OutOrStdout(), "Undo cancelled.")
+			fmt.Fprintln(cmd.OutOrStdout(), "Undo canceled.")
 			return nil
 		}
 	}

--- a/cmd/snap/undo.go
+++ b/cmd/snap/undo.go
@@ -144,7 +144,6 @@ func browseUndoSnapshots(cmd *cobra.Command, api snaplib.RollbackAPI, store *sna
 }
 
 // browseUndoList shows the snapshot picker → card → undo menu for rolled-back snapshots.
-//nolint:gocyclo // Interactive browser flow keeps explicit menu transitions.
 func browseUndoList(cmd *cobra.Command, api snaplib.RollbackAPI, store *snaplib.Store, manifest *snaplib.Manifest, p interactive.Prompter, entries []snaplib.ManifestEntry, allowBack bool) error {
 	labels := undoPickerLabels(store, entries)
 

--- a/cmd/sync/sync_cases.go
+++ b/cmd/sync/sync_cases.go
@@ -58,6 +58,7 @@ Examples:
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		outputFile, _ := cmd.Flags().GetString("output")
 		mappingFile, _ := cmd.Flags().GetString("mapping-file")
+		applySessionFallback(ctx, &srcProject, &dstProject, &srcSuite, &dstSuite)
 
 		p := interactive.PrompterFromContext(ctx)
 		var err error

--- a/cmd/sync/sync_flags.go
+++ b/cmd/sync/sync_flags.go
@@ -1,6 +1,9 @@
 package sync
 
 import (
+	"context"
+
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/snap"
 	"github.com/spf13/cobra"
 )
@@ -18,4 +21,27 @@ func addSyncFlags(c *cobra.Command) {
 	c.Flags().String("mapping-file", "", "Mapping file for shared_step_id replacement")
 	c.Flags().String("output", "", "Additional JSON output")
 	snap.RegisterFlags(c)
+}
+
+// applySessionFallback fills zero project/suite IDs from the work session if available.
+// This enables parameter inheritance: compare → sync → snap.
+func applySessionFallback(ctx context.Context, srcProject, dstProject, srcSuite, dstSuite *int64) {
+	s := interactive.SessionFromContext(ctx)
+	if s == nil {
+		return
+	}
+	sessSrc, sessDst := s.Projects()
+	if *srcProject == 0 {
+		*srcProject = sessSrc
+	}
+	if *dstProject == 0 {
+		*dstProject = sessDst
+	}
+	sessSrcSuite, sessDstSuite := s.Suites()
+	if *srcSuite == 0 {
+		*srcSuite = sessSrcSuite
+	}
+	if *dstSuite == 0 {
+		*dstSuite = sessDstSuite
+	}
 }

--- a/cmd/sync/sync_full.go
+++ b/cmd/sync/sync_full.go
@@ -44,6 +44,7 @@ Examples:
 		autoApprove, _ := cmd.Flags().GetBool("approve")
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
 		autoSaveFiltered, _ := cmd.Flags().GetBool("save-filtered")
+		applySessionFallback(ctx, &srcProject, &dstProject, &srcSuite, &dstSuite)
 
 		p := interactive.PrompterFromContext(ctx)
 		var err error

--- a/cmd/sync/sync_sections.go
+++ b/cmd/sync/sync_sections.go
@@ -47,6 +47,7 @@ Examples:
 
 		var err error
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
+		applySessionFallback(ctx, &srcProject, &dstProject, &srcSuite, &dstSuite)
 
 		p := interactive.PrompterFromContext(ctx)
 

--- a/cmd/sync/sync_shared_steps.go
+++ b/cmd/sync/sync_shared_steps.go
@@ -121,13 +121,32 @@ Examples:
 		sourceSteps := loadedSteps.Source
 		targetSteps := loadedSteps.Target
 
-		// Step 2) Fetch source cases to determine shared steps usage
+		// Step 2) Fetch source cases to determine shared steps usage.
+		// When srcSuite==0 (user opted out of suite selection), load cases
+		// from every suite so filtering works for multi-suite projects.
 		op.Phase("Loading source cases")
-		sourceCases, err := runSyncStatus(ctx, "Loading source cases...", quiet, func(ctx context.Context) (data.GetCasesResponse, error) {
-			return m.Client.GetCases(ctx, srcProject, srcSuite, 0)
-		})
-		if err != nil {
-			return err
+		var sourceCases data.GetCasesResponse
+		if srcSuite != 0 {
+			sourceCases, err = runSyncStatus(ctx, "Loading source cases...", quiet, func(ctx context.Context) (data.GetCasesResponse, error) {
+				return m.Client.GetCases(ctx, srcProject, srcSuite, 0)
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			suites, sErr := m.Client.GetSuites(ctx, srcProject)
+			if sErr != nil {
+				return fmt.Errorf("failed to load suites for project %d: %w", srcProject, sErr)
+			}
+			for _, s := range suites {
+				cases, cErr := runSyncStatus(ctx, fmt.Sprintf("Loading cases from suite %d...", s.ID), quiet, func(ctx context.Context) (data.GetCasesResponse, error) {
+					return m.Client.GetCases(ctx, srcProject, s.ID, 0)
+				})
+				if cErr != nil {
+					return fmt.Errorf("failed to load cases for suite %d: %w", s.ID, cErr)
+				}
+				sourceCases = append(sourceCases, cases...)
+			}
 		}
 		caseIDsSet := make(map[int64]struct{})
 		for _, c := range sourceCases {

--- a/cmd/sync/sync_shared_steps.go
+++ b/cmd/sync/sync_shared_steps.go
@@ -48,6 +48,7 @@ Examples:
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
 		autoSaveFiltered, _ := cmd.Flags().GetBool("save-filtered")
+		applySessionFallback(ctx, &srcProject, &dstProject, &srcSuite, new(int64))
 
 		p := interactive.PrompterFromContext(ctx)
 		var err error

--- a/cmd/sync/sync_snap_helpers.go
+++ b/cmd/sync/sync_snap_helpers.go
@@ -107,25 +107,27 @@ func syncPostAction(ctx context.Context, cmd *cobra.Command, hook *snap.Hook, cl
 	}
 
 	const (
-		optExit     = "✕ Exit"
-		optRollback = "↻ Rollback this migration"
-		optCompare  = "📊 Compare: verify sync results"
-		optSnap     = "📦 Snap: manage snapshots"
+		optExit     = "exit"
+		optRollback = "rollback"
 	)
 
 	for {
-		options := []string{optExit}
-		if hasSnap {
-			options = append(options, optRollback)
+		options := []interactive.ActionOption{
+			{Label: interactive.OptExit, Key: optExit},
 		}
-		options = append(options, optCompare, optSnap)
+		if hasSnap {
+			options = append(options, interactive.ActionOption{Label: "↻ Rollback this migration", Key: optRollback})
+		}
+		options = append(options, interactive.CrossNavOptions()...)
 
-		_, choice, err := p.Select("Post-migration:", options)
+		key, err := interactive.ActionMenu(ctx, p, "Post-migration:", options)
 		if err != nil {
 			return
 		}
 
-		switch choice {
+		switch key {
+		case optExit:
+			return
 		case optRollback:
 			ok, err := p.Confirm("⚠ Are you sure you want to rollback?", false)
 			if err != nil || !ok {
@@ -139,21 +141,9 @@ func syncPostAction(ctx context.Context, cmd *cobra.Command, hook *snap.Hook, cl
 			}
 			ui.Successf(os.Stdout, "✓ Rollback complete: %s", result.Message)
 			return
-
-		case optCompare:
-			if err := interactive.RunSubcommand(ctx, cmd.Root(), "compare", "all"); err != nil {
-				ui.Error(os.Stdout, err.Error())
-			}
+		default:
+			interactive.HandleCrossNav(ctx, cmd, key)
 			continue
-
-		case optSnap:
-			if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
-				ui.Error(os.Stdout, err.Error())
-			}
-			continue
-
-		default: // Exit
-			return
 		}
 	}
 }

--- a/cmd/sync/sync_snap_helpers.go
+++ b/cmd/sync/sync_snap_helpers.go
@@ -141,33 +141,19 @@ func syncPostAction(ctx context.Context, cmd *cobra.Command, hook *snap.Hook, cl
 			return
 
 		case optCompare:
-			runCompareFromPostAction(ctx, cmd)
+			if err := interactive.RunSubcommand(ctx, cmd.Root(), "compare", "all"); err != nil {
+				ui.Error(os.Stdout, err.Error())
+			}
 			continue
 
 		case optSnap:
-			runSnapListFromPostAction(ctx, cmd)
+			if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
+				ui.Error(os.Stdout, err.Error())
+			}
 			continue
 
 		default: // Exit
 			return
 		}
 	}
-}
-
-// runCompareFromPostAction launches compare all from a post-action menu.
-func runCompareFromPostAction(ctx context.Context, cmd *cobra.Command) {
-	fmt.Println()
-	if err := interactive.RunSubcommand(ctx, cmd.Root(), "compare", "all"); err != nil {
-		ui.Error(os.Stdout, err.Error())
-	}
-	fmt.Println()
-}
-
-// runSnapListFromPostAction launches snap list from a post-action menu.
-func runSnapListFromPostAction(ctx context.Context, cmd *cobra.Command) {
-	fmt.Println()
-	if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
-		ui.Error(os.Stdout, err.Error())
-	}
-	fmt.Println()
 }

--- a/cmd/sync/sync_snap_helpers.go
+++ b/cmd/sync/sync_snap_helpers.go
@@ -85,31 +85,42 @@ func printPreConfirmSummary(count int, entityName string, sd snapshotDecision) {
 	}
 }
 
-// syncPostAction shows a post-migration action menu when a snapshot was taken.
+// syncPostAction shows a post-migration action menu.
 // hook is the Hook returned by HookMutation (may be nil or disabled).
 // cli is the API client for rollback operations.
 func syncPostAction(ctx context.Context, cmd *cobra.Command, hook *snap.Hook, cli client.ClientInterface) {
-	if hook == nil || !hook.Enabled || hook.Snap == nil {
+	if !interactive.HasPrompterInContext(ctx) || interactive.IsNonInteractive(ctx) {
 		return
-	}
-
-	snapID := hook.Snap.Meta.ID
-	label := hook.Snap.Meta.Label
-	if label != "" {
-		ui.Infof(os.Stdout, "📦 Snapshot saved: %s (🏷 %s)", snapID, label)
-	} else {
-		ui.Infof(os.Stdout, "📦 Snapshot saved: %s", snapID)
 	}
 
 	p := interactive.PrompterFromContext(ctx)
 
+	hasSnap := hook != nil && hook.Enabled && hook.Snap != nil
+	if hasSnap {
+		snapID := hook.Snap.Meta.ID
+		label := hook.Snap.Meta.Label
+		if label != "" {
+			ui.Infof(os.Stdout, "📦 Snapshot saved: %s (🏷 %s)", snapID, label)
+		} else {
+			ui.Infof(os.Stdout, "📦 Snapshot saved: %s", snapID)
+		}
+	}
+
 	const (
 		optExit     = "✕ Exit"
 		optRollback = "↻ Rollback this migration"
+		optCompare  = "📊 Compare: verify sync results"
+		optSnap     = "📦 Snap: manage snapshots"
 	)
 
 	for {
-		_, choice, err := p.Select("Post-migration:", []string{optExit, optRollback})
+		options := []string{optExit}
+		if hasSnap {
+			options = append(options, optRollback)
+		}
+		options = append(options, optCompare, optSnap)
+
+		_, choice, err := p.Select("Post-migration:", options)
 		if err != nil {
 			return
 		}
@@ -121,7 +132,7 @@ func syncPostAction(ctx context.Context, cmd *cobra.Command, hook *snap.Hook, cl
 				continue
 			}
 
-			result, err := snap.Rollback(ctx, cli, hook.Store, hook.Manifest, snapID)
+			result, err := snap.Rollback(ctx, cli, hook.Store, hook.Manifest, hook.Snap.Meta.ID)
 			if err != nil {
 				ui.Error(os.Stdout, fmt.Sprintf("Rollback failed: %v", err))
 				return
@@ -129,8 +140,34 @@ func syncPostAction(ctx context.Context, cmd *cobra.Command, hook *snap.Hook, cl
 			ui.Successf(os.Stdout, "✓ Rollback complete: %s", result.Message)
 			return
 
+		case optCompare:
+			runCompareFromPostAction(ctx, cmd)
+			continue
+
+		case optSnap:
+			runSnapListFromPostAction(ctx, cmd)
+			continue
+
 		default: // Exit
 			return
 		}
 	}
+}
+
+// runCompareFromPostAction launches compare all from a post-action menu.
+func runCompareFromPostAction(ctx context.Context, cmd *cobra.Command) {
+	fmt.Println()
+	if err := interactive.RunSubcommand(ctx, cmd.Root(), "compare", "all"); err != nil {
+		ui.Error(os.Stdout, err.Error())
+	}
+	fmt.Println()
+}
+
+// runSnapListFromPostAction launches snap list from a post-action menu.
+func runSnapListFromPostAction(ctx context.Context, cmd *cobra.Command) {
+	fmt.Println()
+	if err := interactive.RunSubcommand(ctx, cmd.Root(), "snap", "list"); err != nil {
+		ui.Error(os.Stdout, err.Error())
+	}
+	fmt.Println()
 }

--- a/cmd/sync/sync_suites.go
+++ b/cmd/sync/sync_suites.go
@@ -47,11 +47,24 @@ Flags:
 		autoApprove, _ := cmd.Flags().GetBool("approve")
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
 
-		if srcProject == 0 || dstProject == 0 {
-			return fmt.Errorf("required IDs: --src-project and --dst-project")
+		p := interactive.PrompterFromContext(ctx)
+		var err error
+
+		// Interactive source project selection
+		if srcProject == 0 {
+			srcProject, err = interactive.SelectProject(ctx, p, cli, "Select SOURCE project:")
+			if err != nil {
+				return err
+			}
 		}
 
-		p := interactive.PrompterFromContext(ctx)
+		// Interactive destination project selection
+		if dstProject == 0 {
+			dstProject, err = interactive.SelectProject(ctx, p, cli, "Select DESTINATION project:")
+			if err != nil {
+				return err
+			}
+		}
 
 		logDir, err := paths.EnsureLogsDirPath()
 		if err != nil {

--- a/cmd/sync/sync_suites.go
+++ b/cmd/sync/sync_suites.go
@@ -46,6 +46,7 @@ Flags:
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		autoApprove, _ := cmd.Flags().GetBool("approve")
 		autoSaveMapping, _ := cmd.Flags().GetBool("save-mapping")
+		applySessionFallback(ctx, &srcProject, &dstProject, new(int64), new(int64))
 
 		p := interactive.PrompterFromContext(ctx)
 		var err error

--- a/cmd/sync/sync_suites_test.go
+++ b/cmd/sync/sync_suites_test.go
@@ -136,13 +136,17 @@ func TestSyncSuites_Confirm_NonInteractive_Error(t *testing.T) {
 	assert.False(t, addCalled, "AddSuite should not be called in non-interactive")
 }
 
-func TestSyncSuites_RequiredIDs_ReturnsError(t *testing.T) {
+func TestSyncSuites_RequiredIDs_InteractiveWithFlags(t *testing.T) {
+	// When both project IDs are provided via flags, no interactive prompt is needed.
+	// Without a client, the command still fails — but not on project selection.
 	resetSuitesFlags()
 	cmd := suitesCmd
+	cmd.Flags().Set("src-project", "1")
+	cmd.Flags().Set("dst-project", "2")
 
 	err := cmd.RunE(cmd, []string{})
+	// Should fail on migration init (no client), not on project selection.
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "required IDs")
 }
 
 func TestSyncSuites_ConfirmDeclined_SkipsImport(t *testing.T) {

--- a/cmd/test/interactive_helpers.go
+++ b/cmd/test/interactive_helpers.go
@@ -66,15 +66,5 @@ func resolveTestIDInteractive(ctx context.Context, cli client.ClientInterface) (
 		return 0, fmt.Errorf("no tests found for run %d", runID)
 	}
 
-	options := make([]string, 0, len(tests))
-	for i, test := range tests {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, test.ID, test.Title))
-	}
-
-	idx, _, err := p.Select("Select test:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select test: %w", err)
-	}
-
-	return tests[idx].ID, nil
+	return interactive.SelectTest(ctx, p, tests, "")
 }

--- a/cmd/tests/update.go
+++ b/cmd/tests/update.go
@@ -80,7 +80,11 @@ assign an executor.`,
 			}
 
 			ui.Successf(os.Stdout, "Test %d updated", testID)
-			return printJSON(cmd, resp, time.Now())
+			if err := printJSON(cmd, resp, time.Now()); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/users/add.go
+++ b/cmd/users/add.go
@@ -6,6 +6,7 @@ package users
 import (
 	"fmt"
 
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/snap"
@@ -65,7 +66,11 @@ Administrative privileges are required to create users.`,
 			}
 
 			_, err = output.Output(cmd, user, "users", "json")
-			return err
+			if err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/users/interactive_helpers.go
+++ b/cmd/users/interactive_helpers.go
@@ -19,11 +19,23 @@ func resolveUserIDInteractive(ctx context.Context, cli client.ClientInterface) (
 	if len(users) == 0 {
 		return 0, fmt.Errorf("no users found")
 	}
-	items := make([]string, len(users))
-	for i, user := range users {
-		items[i] = fmt.Sprintf("[%d] ID: %d | %s | %s", i+1, user.ID, user.Name, user.Email)
+
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+		{Header: "Email"},
 	}
-	idx, _, err := p.Select("Select user:", items)
+	rows := make([][]string, len(users))
+	for i, user := range users {
+		rows[i] = []string{fmt.Sprintf("%d", user.ID), user.Name, user.Email}
+	}
+	header, items := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select user:",
+		Header: header,
+		Items:  items,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select user: %w", err)
 	}
@@ -40,11 +52,22 @@ func resolveEmailInteractive(ctx context.Context, cli client.ClientInterface) (s
 	if len(users) == 0 {
 		return "", fmt.Errorf("no users found")
 	}
-	items := make([]string, len(users))
-	for i, user := range users {
-		items[i] = fmt.Sprintf("[%d] %s | %s", i+1, user.Email, user.Name)
+
+	cols := []interactive.Column{
+		{Header: "Email"},
+		{Header: "Name"},
 	}
-	idx, _, err := p.Select("Select user:", items)
+	rows := make([][]string, len(users))
+	for i, user := range users {
+		rows[i] = []string{user.Email, user.Name}
+	}
+	header, items := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select user:",
+		Header: header,
+		Items:  items,
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to select user: %w", err)
 	}

--- a/cmd/users/update.go
+++ b/cmd/users/update.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Korrnals/gotr/internal/flags"
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/models/data"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/snap"
@@ -101,7 +102,11 @@ Administrative privileges are required to modify users.`,
 			}
 
 			_, err = output.Output(cmd, user, "users", "json")
-			return err
+			if err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/variables/add.go
+++ b/cmd/variables/add.go
@@ -74,7 +74,11 @@ the TestRail web interface.`,
 			hook.FinalizeAdd(resp.ID)
 
 			ui.Successf(os.Stdout, "Variable created (ID: %d)", resp.ID)
-			return output.OutputResult(cmd, resp, "variables")
+			if err := output.OutputResult(cmd, resp, "variables"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/variables/delete.go
+++ b/cmd/variables/delete.go
@@ -66,6 +66,7 @@ Use --dry-run to preview before deleting.`,
 			}
 
 			ui.Successf(os.Stdout, "Variable %d deleted", variableID)
+			interactive.MutationPostAction(ctx, cmd)
 			return nil
 		},
 	}

--- a/cmd/variables/interactive_helpers.go
+++ b/cmd/variables/interactive_helpers.go
@@ -25,7 +25,7 @@ func resolveDatasetIDInteractive(ctx context.Context, cli client.ClientInterface
 		return 0, fmt.Errorf("no datasets found in project %d", projectID)
 	}
 
-	return selectDatasetID(ctx, datasets)
+	return interactive.SelectDataset(ctx, p, datasets, "")
 }
 
 // resolveVariableIDInteractive prompts the user to select a dataset, then a variable.
@@ -46,31 +46,25 @@ func resolveVariableIDInteractive(ctx context.Context, cli client.ClientInterfac
 	return selectVariableID(ctx, variables)
 }
 
-// selectDatasetID presents a selection prompt for datasets.
-func selectDatasetID(ctx context.Context, datasets data.GetDatasetsResponse) (int64, error) {
-	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(datasets))
-	for i, dataset := range datasets {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, dataset.ID, dataset.Name))
-	}
-
-	idx, _, err := p.Select("Select dataset:", options)
-	if err != nil {
-		return 0, fmt.Errorf("failed to select dataset: %w", err)
-	}
-
-	return datasets[idx].ID, nil
-}
-
 // selectVariableID presents a selection prompt for variables.
 func selectVariableID(ctx context.Context, variables data.GetVariablesResponse) (int64, error) {
 	p := interactive.PrompterFromContext(ctx)
-	options := make([]string, 0, len(variables))
-	for i, variable := range variables {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, variable.ID, variable.Name))
-	}
 
-	idx, _, err := p.Select("Select variable:", options)
+	cols := []interactive.Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(variables))
+	for i, v := range variables {
+		rows[i] = []string{fmt.Sprintf("%d", v.ID), v.Name}
+	}
+	header, options := interactive.AlignedLabels(cols, rows)
+
+	idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+		Prompt: "Select variable:",
+		Header: header,
+		Items:  options,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to select variable: %w", err)
 	}

--- a/cmd/variables/update.go
+++ b/cmd/variables/update.go
@@ -69,7 +69,11 @@ To modify values, use the TestRail web interface.`,
 			}
 
 			ui.Successf(os.Stdout, "Variable %d updated", variableID)
-			return output.OutputResult(cmd, resp, "variables")
+			if err := output.OutputResult(cmd, resp, "variables"); err != nil {
+				return err
+			}
+			interactive.MutationPostAction(ctx, cmd)
+			return nil
 		},
 	}
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -55,7 +55,7 @@ func runWorkHub(cmd *cobra.Command) error {
 	p := interactive.PrompterFromContext(ctx)
 
 	// Server confirmation — first step before any work.
-	baseURL := viper.GetString("base_url")
+	baseURL := GetServerURLFromCtx(ctx)
 	serverURL, err := interactive.SelectServer(ctx, p, baseURL)
 	if err != nil {
 		if interactive.IsGoBack(err) || interactive.IsExit(err) || interactive.IsInterrupt(err) {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Korrnals/gotr/internal/interactive"
+	"github.com/Korrnals/gotr/internal/ui"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// workCmd is the interactive workspace entry point.
+var workCmd = &cobra.Command{
+	Use:   "work",
+	Short: "Interactive workspace — central entry point",
+	Long: `Launches an interactive session where you can navigate between
+all gotr commands without restarting the CLI.
+
+Use this as the main entry point for interactive work with TestRail.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWorkHub(cmd)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(workCmd)
+}
+
+// workGroup is a top-level hub menu entry.
+type workGroup struct {
+	label string
+	key   string
+}
+
+var workGroups = []workGroup{
+	{"📊 Compare — compare resources between projects", "compare"},
+	{"🔄 Sync — migrate data between projects", "sync"},
+	{"📦 Snap — snapshots and rollback", "snap"},
+	{"📋 Get — retrieve resource details", "get"},
+	{"📝 Add — create resources", "add"},
+	{"🗑  Delete — remove resources", "delete"},
+	{"✏️  Update — modify resources", "update"},
+	{"📤 Export — export data to files", "export"},
+	{"⚙️  Config — view/edit configuration", "config"},
+}
+
+func runWorkHub(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	if !interactive.HasPrompterInContext(ctx) || interactive.IsNonInteractive(ctx) {
+		return fmt.Errorf("gotr work requires interactive mode (remove --non-interactive)")
+	}
+
+	p := interactive.PrompterFromContext(ctx)
+
+	// Server confirmation — first step before any work.
+	baseURL := viper.GetString("base_url")
+	if baseURL == "" {
+		return fmt.Errorf("no server configured; run 'gotr config init' first")
+	}
+	ok, err := p.Confirm(fmt.Sprintf("⚡ You are connecting to: %s. Continue?", baseURL), true)
+	if err != nil {
+		if interactive.IsGoBack(err) || interactive.IsExit(err) || interactive.IsInterrupt(err) {
+			return nil
+		}
+		return fmt.Errorf("server confirmation: %w", err)
+	}
+	if !ok {
+		ui.Infof(os.Stdout, "Session cancelled. Configure another server with 'gotr config init'.")
+		return nil
+	}
+
+	printWorkHeader()
+
+	// Create a work session and inject into context for parameter inheritance.
+	session := &interactive.WorkSession{ServerURL: baseURL}
+	ctx = interactive.WithSession(ctx, session)
+
+	labels := make([]string, len(workGroups))
+	for i, g := range workGroups {
+		labels[i] = g.label
+	}
+
+	for {
+		idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+			Prompt:    "What do you want to do?",
+			Items:     labels,
+			AllowBack: false,
+		})
+		if err != nil {
+			if interactive.IsExit(err) || interactive.IsGoBack(err) {
+				return nil
+			}
+			return err
+		}
+
+		selected := workGroups[idx]
+		if err := dispatchWorkGroup(ctx, cmd, selected.key); err != nil {
+			if interactive.IsGoBack(err) || interactive.IsExit(err) {
+				continue
+			}
+			ui.Error(os.Stdout, fmt.Sprintf("%v", err))
+		}
+	}
+}
+
+func printWorkHeader() {
+	baseURL := viper.GetString("base_url")
+	if baseURL == "" {
+		baseURL = "(not configured)"
+	}
+	fmt.Println()
+	fmt.Println("╔══ gotr interactive workspace ══════════════════════╗")
+	fmt.Printf("║  Server: %-42s║\n", baseURL)
+	fmt.Println("╚═══════════════════════════════════════════════════╝")
+	fmt.Println()
+}
+
+func dispatchWorkGroup(ctx context.Context, cmd *cobra.Command, key string) error {
+	switch key {
+	case "compare":
+		return workCompareHub(ctx, cmd)
+	case "sync":
+		return workSyncHub(ctx, cmd)
+	case "snap":
+		return workSnapHub(ctx, cmd)
+	default:
+		return runSubcommandHub(ctx, cmd, key)
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -56,25 +56,18 @@ func runWorkHub(cmd *cobra.Command) error {
 
 	// Server confirmation — first step before any work.
 	baseURL := viper.GetString("base_url")
-	if baseURL == "" {
-		return fmt.Errorf("no server configured; run 'gotr config init' first")
-	}
-	ok, err := p.Confirm(fmt.Sprintf("⚡ You are connecting to: %s. Continue?", baseURL), true)
+	serverURL, err := interactive.SelectServer(ctx, p, baseURL)
 	if err != nil {
 		if interactive.IsGoBack(err) || interactive.IsExit(err) || interactive.IsInterrupt(err) {
 			return nil
 		}
-		return fmt.Errorf("server confirmation: %w", err)
-	}
-	if !ok {
-		ui.Infof(os.Stdout, "Session cancelled. Configure another server with 'gotr config init'.")
-		return nil
+		return err
 	}
 
 	printWorkHeader()
 
 	// Create a work session and inject into context for parameter inheritance.
-	session := &interactive.WorkSession{ServerURL: baseURL}
+	session := &interactive.WorkSession{ServerURL: serverURL}
 	ctx = interactive.WithSession(ctx, session)
 
 	labels := make([]string, len(workGroups))

--- a/cmd/work_hub.go
+++ b/cmd/work_hub.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Korrnals/gotr/internal/interactive"
+	"github.com/Korrnals/gotr/internal/ui"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type hubEntry struct {
+	label      string
+	subcommand string
+}
+
+// workCompareHub presents an interactive menu for compare subcommands.
+func workCompareHub(ctx context.Context, cmd *cobra.Command) error {
+	entries := []hubEntry{
+		{"All resources (full scan)", "all"},
+		{"Cases", "cases"},
+		{"Suites", "suites"},
+		{"Sections", "sections"},
+		{"Shared steps", "sharedsteps"},
+		{"Runs", "runs"},
+		{"Plans", "plans"},
+		{"Milestones", "milestones"},
+		{"Datasets", "datasets"},
+		{"Groups", "groups"},
+		{"Labels", "labels"},
+		{"Templates", "templates"},
+		{"Configurations", "configurations"},
+	}
+	return genericHub(ctx, cmd, "compare", "Compare — what to compare?", entries)
+}
+
+// workSyncHub presents an interactive menu for sync subcommands.
+func workSyncHub(ctx context.Context, cmd *cobra.Command) error {
+	entries := []hubEntry{
+		{"Full migration (cases + shared steps) ★", "full"},
+		{"Cases", "cases"},
+		{"Shared steps", "shared-steps"},
+		{"Suites", "suites"},
+		{"Sections", "sections"},
+	}
+	return genericHub(ctx, cmd, "sync", "Sync — what to migrate?", entries)
+}
+
+// workSnapHub presents an interactive menu for snap subcommands.
+func workSnapHub(ctx context.Context, cmd *cobra.Command) error {
+	entries := []hubEntry{
+		{"📋 List snapshots", "list"},
+		{"🔍 View snapshot details", "info"},
+		{"↻ Rollback a snapshot", "rollback"},
+		{"📤 Export snapshot", "export"},
+		{"🗑  Delete snapshot", "delete"},
+		{"🧹 Garbage collection", "gc"},
+	}
+	return genericHub(ctx, cmd, "snap", "Snap — what to do?", entries)
+}
+
+// runSubcommandHub handles generic command groups (get, add, delete, update, export, config)
+// by discovering subcommands from the cobra tree.
+func runSubcommandHub(ctx context.Context, cmd *cobra.Command, groupName string) error {
+	root := cmd.Root()
+	groupCmd, err := interactive.FindSubcommand(root, groupName)
+	if err != nil {
+		return fmt.Errorf("command group '%s' not found: %w", groupName, err)
+	}
+
+	subs := groupCmd.Commands()
+	if len(subs) == 0 {
+		// Leaf command — run it directly.
+		groupCmd.SetContext(ctx)
+		return groupCmd.RunE(groupCmd, nil)
+	}
+
+	entries := make([]hubEntry, 0, len(subs))
+	for _, s := range subs {
+		if s.Hidden || !s.IsAvailableCommand() {
+			continue
+		}
+		entries = append(entries, hubEntry{
+			label:      s.Name() + " — " + s.Short,
+			subcommand: s.Name(),
+		})
+	}
+
+	return genericHub(ctx, cmd, groupName, groupCmd.Short+" — choose action:", entries)
+}
+
+// genericHub is the core loop: show a Browse menu, find and run the subcommand,
+// then return to the menu. Back returns to the work hub.
+func genericHub(ctx context.Context, cmd *cobra.Command, group, prompt string, entries []hubEntry) error {
+	p := interactive.PrompterFromContext(ctx)
+	root := cmd.Root()
+
+	labels := make([]string, len(entries))
+	for i, e := range entries {
+		labels[i] = e.label
+	}
+
+	for {
+		idx, err := interactive.Browse(ctx, p, interactive.BrowseConfig{
+			Prompt:    prompt,
+			Items:     labels,
+			AllowBack: true,
+		})
+		if err != nil {
+			return err // ErrGoBack → back to work hub
+		}
+
+		subName := entries[idx].subcommand
+		subCmd, findErr := interactive.FindSubcommand(root, group, subName)
+		if findErr != nil {
+			ui.Error(os.Stdout, findErr.Error())
+			continue
+		}
+
+		subCmd.SetContext(ctx)
+		if runErr := subCmd.RunE(subCmd, nil); runErr != nil {
+			if interactive.IsGoBack(runErr) || interactive.IsExit(runErr) {
+				continue
+			}
+			ui.Error(os.Stdout, fmt.Sprintf("%v", runErr))
+		}
+		// Reset changed flags to avoid stale state on repeated invocations.
+		subCmd.Flags().Visit(func(f *pflag.Flag) {
+			f.Changed = false
+		})
+		fmt.Println()
+	}
+}

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -40,7 +40,8 @@ func TestRunWorkHub_ServerConfirmReject(t *testing.T) {
 	defer viper.Set("base_url", "")
 
 	p := interactive.NewMockPrompter().WithConfirmResponses(false)
-	ctx := interactive.WithPrompter(context.Background(), p)
+	ctx := context.WithValue(context.Background(), serverURLKey, "https://test.testrail.io")
+	ctx = interactive.WithPrompter(ctx, p)
 
 	cmd := &cobra.Command{Use: "work"}
 	cmd.SetContext(ctx)
@@ -57,7 +58,8 @@ func TestRunWorkHub_ServerConfirmAccept_ThenExit(t *testing.T) {
 	p := interactive.NewMockPrompter().
 		WithConfirmResponses(true).
 		WithSelectResponses(interactive.SelectResponse{Index: -1}) // Browse exhausts → error → exit
-	ctx := interactive.WithPrompter(context.Background(), p)
+	ctx := context.WithValue(context.Background(), serverURLKey, "https://test.testrail.io")
+	ctx = interactive.WithPrompter(ctx, p)
 
 	cmd := &cobra.Command{Use: "work"}
 	cmd.SetContext(ctx)
@@ -74,7 +76,8 @@ func TestRunWorkHub_SessionInjected(t *testing.T) {
 	p := interactive.NewMockPrompter().
 		WithConfirmResponses(true).
 		WithSelectResponses(interactive.SelectResponse{Index: -1})
-	ctx := interactive.WithPrompter(context.Background(), p)
+	ctx := context.WithValue(context.Background(), serverURLKey, "https://session.testrail.io")
+	ctx = interactive.WithPrompter(ctx, p)
 
 	cmd := &cobra.Command{Use: "work"}
 	cmd.SetContext(ctx)

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Korrnals/gotr/internal/interactive"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWorkHub_NonInteractive(t *testing.T) {
+	cmd := &cobra.Command{Use: "work"}
+	cmd.SetContext(context.Background())
+
+	err := runWorkHub(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "interactive mode")
+}
+
+func TestRunWorkHub_NoServer(t *testing.T) {
+	viper.Set("base_url", "")
+	defer viper.Set("base_url", "")
+
+	p := interactive.NewMockPrompter()
+	ctx := interactive.WithPrompter(context.Background(), p)
+
+	cmd := &cobra.Command{Use: "work"}
+	cmd.SetContext(ctx)
+
+	err := runWorkHub(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no server configured")
+}
+
+func TestRunWorkHub_ServerConfirmReject(t *testing.T) {
+	viper.Set("base_url", "https://test.testrail.io")
+	defer viper.Set("base_url", "")
+
+	p := interactive.NewMockPrompter().WithConfirmResponses(false)
+	ctx := interactive.WithPrompter(context.Background(), p)
+
+	cmd := &cobra.Command{Use: "work"}
+	cmd.SetContext(ctx)
+
+	err := runWorkHub(cmd)
+	assert.NoError(t, err, "rejecting server should return nil, not error")
+}
+
+func TestRunWorkHub_ServerConfirmAccept_ThenExit(t *testing.T) {
+	viper.Set("base_url", "https://test.testrail.io")
+	defer viper.Set("base_url", "")
+
+	// Accept server confirmation, then Browse returns exit error.
+	p := interactive.NewMockPrompter().
+		WithConfirmResponses(true).
+		WithSelectResponses(interactive.SelectResponse{Index: -1}) // Browse exhausts → error → exit
+	ctx := interactive.WithPrompter(context.Background(), p)
+
+	cmd := &cobra.Command{Use: "work"}
+	cmd.SetContext(ctx)
+
+	err := runWorkHub(cmd)
+	assert.NoError(t, err)
+}
+
+func TestRunWorkHub_SessionInjected(t *testing.T) {
+	viper.Set("base_url", "https://session.testrail.io")
+	defer viper.Set("base_url", "")
+
+	// Accept server, then exit on menu.
+	p := interactive.NewMockPrompter().
+		WithConfirmResponses(true).
+		WithSelectResponses(interactive.SelectResponse{Index: -1})
+	ctx := interactive.WithPrompter(context.Background(), p)
+
+	cmd := &cobra.Command{Use: "work"}
+	cmd.SetContext(ctx)
+
+	// We can't inspect the session directly because ctx is modified inside runWorkHub.
+	// But we verify no panic and the function runs cleanly.
+	err := runWorkHub(cmd)
+	assert.NoError(t, err)
+}
+
+func TestDispatchWorkGroup_Compare(t *testing.T) {
+	ctx := context.Background()
+	cmd := &cobra.Command{Use: "root"}
+	// No subcommands registered, so dispatch should fail gracefully.
+	err := dispatchWorkGroup(ctx, cmd, "compare")
+	// compare hub requires a prompter in context — will return error.
+	require.Error(t, err)
+}
+
+func TestDispatchWorkGroup_UnknownGroup(t *testing.T) {
+	ctx := context.Background()
+	cmd := &cobra.Command{Use: "root"}
+	err := dispatchWorkGroup(ctx, cmd, "nonexistent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestWorkCmd_Properties(t *testing.T) {
+	assert.Equal(t, "work", workCmd.Use)
+	assert.NotEmpty(t, workCmd.Short)
+	assert.NotNil(t, workCmd.RunE)
+}
+
+func TestWorkGroups_NotEmpty(t *testing.T) {
+	assert.True(t, len(workGroups) >= 5, "should have at least 5 work groups")
+	for _, g := range workGroups {
+		assert.NotEmpty(t, g.label)
+		assert.NotEmpty(t, g.key)
+	}
+}
+
+func TestPrintWorkHeader_NoPanic(t *testing.T) {
+	viper.Set("base_url", "https://test.testrail.io")
+	defer viper.Set("base_url", "")
+	assert.NotPanics(t, printWorkHeader)
+}
+
+func TestPrintWorkHeader_NoPanic_Empty(t *testing.T) {
+	viper.Set("base_url", "")
+	assert.NotPanics(t, printWorkHeader)
+}

--- a/docs/ru/architecture/ux-modernization-design.md
+++ b/docs/ru/architecture/ux-modernization-design.md
@@ -1,0 +1,222 @@
+# UX Modernization Design — gotr Interactive Commands
+
+## Цель
+
+Привести весь интерактив gotr к единой стилистике, реализованной в `cmd/snap/`:
+
+- Многоуровневая навигация с Back/Exit
+- Выровненные колонки с заголовками
+- Группировка по категориям
+- Карточки деталей + action-меню
+- JSON-приоритет при сохранении (interactive → table, file save → JSON)
+
+## Эталон: cmd/snap/
+
+- 4 уровня: Server → Operation → Resource → Snapshot
+- `alignedPickerLabels()` — авто-ширина колонок + header
+- `errGoBack`/`errExit` sentinels — навигация Back/Exit
+- `renderInfoCard()` — детальная карточка
+- `postCardAction()` — action-меню после карточки
+- `groupByOperation()`, `groupByCategory()` — вложенная группировка
+
+## Текущее состояние по группам
+
+### Tier 1 — Максимальный импакт (много данных, частое использование)
+
+| Группа | Текущий паттерн | Что нужно |
+|--------|----------------|-----------|
+| cmd/cases/ | Project→Suite→Case, flat `[i] ID: X \| Title` | Aligned labels, Back/Exit, info card, grouping by section |
+| cmd/get/ | Project→Suite→Item, flat | Aligned labels, Back/Exit, info card |
+| cmd/compare/ | Complex flow | Aligned labels, navigation |
+| cmd/sync/ | Select+Confirm chains | Back/Exit, aligned labels, preview cards, **snapshot integration** |
+
+### Tier 2 — Средний импакт (умеренные списки)
+
+| Группа | Текущий паттерн | Что нужно |
+|--------|----------------|-----------|
+| cmd/attachments/ | 3-level deep hierarchy | Back/Exit, aligned, cards |
+| cmd/test/, cmd/tests/ | Project→Run→Test | Aligned labels, Back/Exit |
+| cmd/run/ | Project→Suite→Run | Aligned labels, grouped by status |
+| cmd/plans/ | Project→Plan→Entry | Aligned, cards |
+| cmd/configurations/ | Group→Config | Aligned, Back/Exit |
+
+### Tier 3 — Минимальный (короткие списки, редко)
+
+| Группа | Текущий паттерн | Что нужно |
+|--------|----------------|-----------|
+| cmd/list/ | Flat resource select | Minimal — уже ок |
+| cmd/delete/ | Endpoint→Item | Back/Exit, confirm card |
+| cmd/add/, cmd/update/ | Input fields | Minimal changes |
+| cmd/export/ | Resource→Endpoint→ID | Back/Exit |
+| cmd/groups/ | Project→Group | Aligned |
+| cmd/templates/ | Project select | Minimal |
+| cmd/variables/, cmd/datasets/ | Dataset→Variable | Aligned |
+| cmd/labels/, cmd/bdds/ | Flat select | Minimal |
+| cmd/users/, cmd/roles/ | Flat select | Minimal |
+| cmd/reports/ | Template select | Minimal |
+| cmd/milestones/ | Project→Milestone | Aligned |
+| cmd/result/ | Run→Test→Case | Back/Exit, aligned |
+
+## Принципы реализации
+
+### 1. Shared Navigation Kit (internal/interactive/)
+
+Вынести из `cmd/snap/interactive_helpers.go` в `internal/interactive/`:
+
+- `AlignedLabels(columns []Column, rows []Row) []string` — generic aligned formatter
+- `BrowseLoop(cfg BrowseConfig) error` — generic browse with Back/Exit/action
+- `GroupBy(entries, keyFn) []Group` — generic grouper
+- Navigation sentinels: `ErrGoBack`, `ErrExit`
+- `PostAction` enum + `ActionMenu(options)` pattern
+
+### 2. Aligned Label Format
+
+```
+[1] ID: 123 │ cases    │ Regression Test Login │ active  │ 2026-04-13
+[2] ID: 456 │ cases    │ Payment Flow          │ closed  │ 2026-04-12
+```
+
+- Авто-ширина колонок (как в snap)
+- Header row опциональный
+- `│` разделители
+
+### 3. Info Cards
+
+```
+┌─ Case Info ──────────────────┐
+│ ID         │ 12345           │
+│ Title      │ Login Flow      │
+│ Section    │ Auth / Login    │
+│ Priority   │ Critical        │
+│ Status     │ Active          │
+└──────────────────────────────┘
+```
+
+- go-pretty таблица StyleRounded
+- Отображается при выборе элемента
+
+### 4. Action Menu (после карточки)
+
+```
+? Action:
+  ← Back
+  ✕ Exit
+  ↻ Refresh
+  📋 Copy ID
+  💾 Save to file (JSON)
+```
+
+- Контекстные действия зависят от команды
+- Rollback/Undo/Delete — только где применимо
+
+### 5. JSON Output Priority
+
+- **Interactive display** → table (human-readable)
+- **--format json** → JSON to stdout
+- **--save / file save** → JSON по умолчанию (не table!)
+- **Pipe detection**: если stdout не TTY → JSON автоматически
+
+### 6. Grouping Strategy
+
+- Projects → группировка по Suite
+- Cases → группировка по Section
+- Runs → группировка по Status (active/completed)
+- Tests → группировка по Run
+- Configs → группировка по Config Group
+- Attachments → группировка по Entity Type
+
+## Sync — Snapshot Integration (ПРИОРИТЕТ)
+
+### Контекст
+
+Миграция (`gotr sync **`) — самая рискованная операция. Все инструменты безопасности
+(snapshot, rollback, undo) должны быть доступны прямо из потока миграции, а не
+заставлять пользователя переключаться между командами.
+
+### 1. Обязательный Snapshot Prompt перед миграцией
+
+Каждая подкоманда `gotr sync *` перед выполнением спрашивает:
+
+```
+? Create snapshot before migration? (recommended) [Y/n]
+```
+
+- Default: **true** (Yes) — снапшот создаётся всегда, если пользователь не откажется
+- При `--non-interactive`: снапшот создаётся автоматически (без вопроса)
+- При `--no-snapshot`: явно отключается (флаг)
+- Снапшот сохраняется в manifest, ID выводится после создания:
+  `✓ Snapshot created: sync/20260414T120000_sync_cases_0`
+
+### 2. Post-Migration Navigation Menu
+
+После завершения миграции (успех или частичный успех) — action-меню:
+
+```
+? Migration complete. What next?
+  ← Back to sync menu
+  ✕ Exit
+  📋 View migration log
+  ↻ Rollback this migration
+  📦 Browse rollback history
+```
+
+- `↻ Rollback this migration` — вызывает `snap rollback <snapshot_id>` для только что созданного снапшота
+- `📦 Browse rollback history` — открывает `snap rollback list` (browse rolled-back snapshots)
+- `📋 View migration log` — показывает diff/summary выполненных изменений
+
+### 3. Sync Subcommands Scope
+
+Все подкоманды `gotr sync` получают snapshot integration:
+
+- `gotr sync cases` — sync cases between suites
+- `gotr sync suites` — sync suites between projects
+- `gotr sync sections` — sync sections between suites
+- `gotr sync shared-steps` — sync shared steps
+- `gotr sync full` — full project sync (все вышеперечисленное)
+
+### 4. Флаги
+
+- `--snapshot` / `--no-snapshot` — явное управление снапшотом (default: true)
+- `--rollback-on-error` — автоматический rollback при ошибке миграции (future)
+
+## Порядок реализации
+
+### Phase 0: Sync Snapshot Integration (приоритет)
+
+1. Добавить `--snapshot` / `--no-snapshot` флаг ко всем sync подкомандам
+2. Pre-migration snapshot prompt + auto-create
+3. Post-migration action menu (rollback/browse/log)
+4. Интеграция с существующим snap engine
+5. Tests
+
+### Phase 1: Shared Navigation Kit
+
+6. Extract navigation primitives из cmd/snap/ → internal/interactive/
+7. Generic `BrowseLoop`, `AlignedLabels`, `GroupBy`
+8. Tests для kit
+
+### Phase 2: Tier 1 Commands (cases, get, compare, sync)
+
+9. cmd/get/ — aligned labels + Back/Exit + info cards
+10. cmd/cases/ — grouped by section + aligned + cards
+11. cmd/sync/ — navigation + preview cards (поверх Phase 0)
+12. cmd/compare/ — aligned output
+
+### Phase 3: Tier 2 Commands
+
+13. cmd/attachments/, cmd/test/, cmd/run/
+14. cmd/plans/, cmd/configurations/
+15. cmd/result/
+
+### Phase 4: Tier 3 Commands + Polish
+
+16. Remaining commands — minimal aligned labels
+17. Pipe detection → auto-JSON
+18. Final consistency pass
+
+## Ограничения
+
+- НЕ ломать существующий non-interactive (`--non-interactive`) контракт
+- НЕ менять CLI API (flags, args) — только interactive UX
+- JSON schema не меняется — только presentation layer
+- Backward-compatible: старые скрипты продолжают работать

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
+	golang.org/x/term v0.29.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -36,7 +37,6 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )
 

--- a/internal/crud/executor.go
+++ b/internal/crud/executor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/Korrnals/gotr/internal/interactive"
 	"github.com/Korrnals/gotr/internal/output"
 	"github.com/Korrnals/gotr/internal/snap"
 	"github.com/spf13/cobra"
@@ -86,7 +87,12 @@ func Execute[Req any, Resp any](
 		}
 	}
 
-	return output.OutputResult(cmd, result, "result")
+	if err := output.OutputResult(cmd, result, "result"); err != nil {
+		return err
+	}
+
+	interactive.MutationPostAction(ctx, cmd)
+	return nil
 }
 
 // cmdArgs returns the CLI arguments for the current command (for snap metadata).

--- a/internal/interactive/action_menu.go
+++ b/internal/interactive/action_menu.go
@@ -1,0 +1,50 @@
+package interactive
+
+import "context"
+
+// ActionOption is a single option in a post-action menu.
+type ActionOption struct {
+	// Label is the display text (e.g. "↻ Rollback this migration").
+	Label string
+	// Key is a short identifier returned when selected (e.g. "rollback").
+	Key string
+	// Disabled makes the option visible but not selectable.
+	Disabled bool
+	// Hint is shown next to disabled options (e.g. "already rolled back").
+	Hint string
+}
+
+// ActionMenu presents a post-action menu and returns the selected option key.
+// Disabled options trigger a re-prompt loop. Ctrl+C returns ErrExit.
+func ActionMenu(ctx context.Context, p Prompter, prompt string, options []ActionOption) (string, error) {
+	if len(options) == 0 {
+		return "", ErrExit
+	}
+
+	labels := make([]string, len(options))
+	for i, o := range options {
+		if o.Disabled && o.Hint != "" {
+			labels[i] = o.Label + " (" + o.Hint + ")"
+		} else {
+			labels[i] = o.Label
+		}
+	}
+
+	for {
+		idx, _, err := p.Select(prompt, labels)
+		if err != nil {
+			if IsInterrupt(err) {
+				return "", ErrExit
+			}
+			return "", err
+		}
+
+		opt := options[idx]
+		if opt.Disabled {
+			// Re-prompt — user selected a disabled option.
+			continue
+		}
+
+		return opt.Key, nil
+	}
+}

--- a/internal/interactive/action_menu_test.go
+++ b/internal/interactive/action_menu_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestActionMenu_SelectOption(t *testing.T) {
-	// Options: [Exit, Save] → index 1 = Save
-	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 1})
+	// Options: [Exit, Save] → raw index 1 = Save (skip auto-adjust: ActionMenu uses OptExit as label)
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 1, Raw: true})
 
 	key, err := ActionMenu(context.Background(), mock, "What next?", []ActionOption{
 		{Label: OptExit, Key: "exit"},

--- a/internal/interactive/action_menu_test.go
+++ b/internal/interactive/action_menu_test.go
@@ -1,0 +1,35 @@
+package interactive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionMenu_SelectOption(t *testing.T) {
+	// Options: [Exit, Save] → index 1 = Save
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 1})
+
+	key, err := ActionMenu(context.Background(), mock, "What next?", []ActionOption{
+		{Label: OptExit, Key: "exit"},
+		{Label: "💾 Save", Key: "save"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "save", key)
+}
+
+func TestActionMenu_Empty(t *testing.T) {
+	mock := NewMockPrompter()
+	_, err := ActionMenu(context.Background(), mock, "What next?", nil)
+	assert.ErrorIs(t, err, ErrExit)
+}
+
+func TestActionMenu_Interrupt(t *testing.T) {
+	mock := &interruptPrompter{}
+
+	_, err := ActionMenu(context.Background(), mock, "What next?", []ActionOption{
+		{Label: "Test", Key: "test"},
+	})
+	assert.ErrorIs(t, err, ErrExit)
+}

--- a/internal/interactive/aligned.go
+++ b/internal/interactive/aligned.go
@@ -1,0 +1,71 @@
+package interactive
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Column defines a single column in an aligned label table.
+type Column struct {
+	Header string
+	// MinWidth overrides the minimum width. If 0, uses header length.
+	MinWidth int
+}
+
+// AlignedLabels formats rows into equal-width columns separated by │.
+// Returns a header string and formatted label strings for each row.
+// Each row must have the same number of elements as columns.
+func AlignedLabels(columns []Column, rows [][]string) (header string, labels []string) {
+	if len(columns) == 0 || len(rows) == 0 {
+		return "", nil
+	}
+
+	n := len(columns)
+
+	// Compute max widths.
+	widths := make([]int, n)
+	for i, c := range columns {
+		widths[i] = len(c.Header)
+		if c.MinWidth > widths[i] {
+			widths[i] = c.MinWidth
+		}
+	}
+	for _, row := range rows {
+		for i := 0; i < n && i < len(row); i++ {
+			if len(row[i]) > widths[i] {
+				widths[i] = len(row[i])
+			}
+		}
+	}
+
+	// Format function.
+	fmtRow := func(cells []string) string {
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			cell := ""
+			if i < len(cells) {
+				cell = cells[i]
+			}
+			if i > 0 {
+				b.WriteString(" │ ")
+			}
+			fmt.Fprintf(&b, "%-*s", widths[i], cell)
+		}
+		return b.String()
+	}
+
+	// Header.
+	hdrs := make([]string, n)
+	for i, c := range columns {
+		hdrs[i] = c.Header
+	}
+	header = fmtRow(hdrs)
+
+	// Data rows.
+	labels = make([]string, len(rows))
+	for i, row := range rows {
+		labels[i] = fmtRow(row)
+	}
+
+	return header, labels
+}

--- a/internal/interactive/aligned_test.go
+++ b/internal/interactive/aligned_test.go
@@ -1,0 +1,73 @@
+package interactive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlignedLabels_Basic(t *testing.T) {
+	cols := []Column{
+		{Header: "#"},
+		{Header: "NAME"},
+		{Header: "STATUS"},
+	}
+	rows := [][]string{
+		{"[1]", "Alpha", "active"},
+		{"[2]", "Bravo Charlie", "closed"},
+		{"[3]", "D", "active"},
+	}
+
+	header, labels := AlignedLabels(cols, rows)
+
+	// Header uses max widths.
+	assert.Contains(t, header, "#")
+	assert.Contains(t, header, "NAME")
+	assert.Contains(t, header, "STATUS")
+
+	require.Len(t, labels, 3)
+	// All labels should have the same length (padded).
+	assert.Equal(t, len(labels[0]), len(labels[1]))
+	assert.Equal(t, len(labels[1]), len(labels[2]))
+
+	// Second row should contain full name.
+	assert.Contains(t, labels[1], "Bravo Charlie")
+}
+
+func TestAlignedLabels_EmptyInput(t *testing.T) {
+	header, labels := AlignedLabels(nil, nil)
+	assert.Empty(t, header)
+	assert.Nil(t, labels)
+}
+
+func TestAlignedLabels_MinWidth(t *testing.T) {
+	cols := []Column{
+		{Header: "ID", MinWidth: 10},
+		{Header: "VAL"},
+	}
+	rows := [][]string{
+		{"1", "x"},
+	}
+
+	header, labels := AlignedLabels(cols, rows)
+	// ID column should be at least 10 chars wide.
+	assert.True(t, len(header) >= 10)
+	assert.Len(t, labels, 1)
+}
+
+func TestAlignedLabels_Separators(t *testing.T) {
+	cols := []Column{
+		{Header: "A"},
+		{Header: "B"},
+		{Header: "C"},
+	}
+	rows := [][]string{
+		{"1", "2", "3"},
+	}
+
+	_, labels := AlignedLabels(cols, rows)
+	require.Len(t, labels, 1)
+	// Should contain │ separators between columns.
+	assert.Contains(t, labels[0], "│")
+}

--- a/internal/interactive/browse.go
+++ b/internal/interactive/browse.go
@@ -1,0 +1,65 @@
+package interactive
+
+import "context"
+
+// BrowseConfig configures a single-level browse interaction.
+type BrowseConfig struct {
+	// Prompt is the selection prompt text.
+	Prompt string
+	// Header is printed above options (e.g. column headers). Optional.
+	Header string
+	// Items are the selectable option labels.
+	Items []string
+	// AllowBack adds "← Back" at top and bottom of the list.
+	AllowBack bool
+}
+
+// Browse presents a single-level selection with optional Back/Exit.
+// Returns the 0-based index into cfg.Items, or ErrGoBack/ErrExit.
+func Browse(ctx context.Context, p Prompter, cfg BrowseConfig) (int, error) {
+	if len(cfg.Items) == 0 {
+		return 0, ErrGoBack
+	}
+
+	// Build option list: [Back] + Exit + items + [Back].
+	options := make([]string, 0, len(cfg.Items)+4)
+	if cfg.AllowBack {
+		options = append(options, OptBack)
+	}
+	options = append(options, OptExit)
+	itemStart := len(options)
+	options = append(options, cfg.Items...)
+	if cfg.AllowBack && len(cfg.Items) > 5 {
+		options = append(options, OptBack)
+	}
+
+	// Print header if provided.
+	if cfg.Header != "" {
+		// Header is informational — cannot be selected.
+		// We'll show it as part of the prompt.
+		cfg.Prompt = cfg.Prompt + "\n  " + cfg.Header
+	}
+
+	idx, _, err := p.Select(cfg.Prompt, options)
+	if err != nil {
+		if IsInterrupt(err) {
+			return 0, ErrExit
+		}
+		return 0, err
+	}
+
+	selected := options[idx]
+	switch selected {
+	case OptBack:
+		return 0, ErrGoBack
+	case OptExit:
+		return 0, ErrExit
+	default:
+		return idx - itemStart, nil
+	}
+}
+
+// IsInterrupt checks if the error is a context cancellation (Ctrl+C).
+func IsInterrupt(err error) bool {
+	return err == context.Canceled
+}

--- a/internal/interactive/browse_test.go
+++ b/internal/interactive/browse_test.go
@@ -1,0 +1,71 @@
+package interactive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowse_SelectItem(t *testing.T) {
+	// Options will be: [Exit, Alpha, Bravo] → index 2 = Bravo
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 2})
+
+	idx, err := Browse(context.Background(), mock, BrowseConfig{
+		Prompt: "Pick one:",
+		Items:  []string{"Alpha", "Bravo"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, idx) // Bravo is index 1 in Items
+}
+
+func TestBrowse_Exit(t *testing.T) {
+	// Options: [Exit, A] → index 0 = Exit
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0})
+
+	_, err := Browse(context.Background(), mock, BrowseConfig{
+		Prompt: "Pick:",
+		Items:  []string{"A"},
+	})
+	assert.ErrorIs(t, err, ErrExit)
+}
+
+func TestBrowse_Back(t *testing.T) {
+	// Options: [Back, Exit, A] → index 0 = Back
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0})
+
+	_, err := Browse(context.Background(), mock, BrowseConfig{
+		Prompt:    "Pick:",
+		Items:     []string{"A"},
+		AllowBack: true,
+	})
+	assert.ErrorIs(t, err, ErrGoBack)
+}
+
+func TestBrowse_EmptyItems(t *testing.T) {
+	mock := NewMockPrompter()
+	_, err := Browse(context.Background(), mock, BrowseConfig{
+		Prompt: "Pick:",
+		Items:  nil,
+	})
+	assert.ErrorIs(t, err, ErrGoBack)
+}
+
+func TestBrowse_Interrupt(t *testing.T) {
+	mock := &interruptPrompter{}
+
+	_, err := Browse(context.Background(), mock, BrowseConfig{
+		Prompt: "Pick:",
+		Items:  []string{"A"},
+	})
+	assert.ErrorIs(t, err, ErrExit)
+}
+
+// interruptPrompter always returns context.Canceled.
+type interruptPrompter struct{}
+
+func (p *interruptPrompter) Input(string, string) (string, error)        { return "", context.Canceled }
+func (p *interruptPrompter) Confirm(string, bool) (bool, error)          { return false, context.Canceled }
+func (p *interruptPrompter) Select(string, []string) (int, string, error) { return 0, "", context.Canceled }
+func (p *interruptPrompter) MultilineInput(string, string) (string, error) { return "", context.Canceled }

--- a/internal/interactive/browse_test.go
+++ b/internal/interactive/browse_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestBrowse_SelectItem(t *testing.T) {
-	// Options will be: [Exit, Alpha, Bravo] → index 2 = Bravo
-	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 2})
+	// Items: [Alpha, Bravo]. Mock index 1 = Bravo (auto-adjusted past Exit).
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 1})
 
 	idx, err := Browse(context.Background(), mock, BrowseConfig{
 		Prompt: "Pick one:",
@@ -21,8 +21,8 @@ func TestBrowse_SelectItem(t *testing.T) {
 }
 
 func TestBrowse_Exit(t *testing.T) {
-	// Options: [Exit, A] → index 0 = Exit
-	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0})
+	// Raw index 0 = Exit (skip auto-adjustment)
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0, Raw: true})
 
 	_, err := Browse(context.Background(), mock, BrowseConfig{
 		Prompt: "Pick:",
@@ -32,8 +32,8 @@ func TestBrowse_Exit(t *testing.T) {
 }
 
 func TestBrowse_Back(t *testing.T) {
-	// Options: [Back, Exit, A] → index 0 = Back
-	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0})
+	// Raw index 0 = Back (skip auto-adjustment)
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0, Raw: true})
 
 	_, err := Browse(context.Background(), mock, BrowseConfig{
 		Prompt:    "Pick:",

--- a/internal/interactive/cross_nav.go
+++ b/internal/interactive/cross_nav.go
@@ -1,0 +1,62 @@
+package interactive
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// NavPrefix is the key prefix for cross-module navigation actions.
+const NavPrefix = "nav:"
+
+// CrossNavOptions returns the standard cross-navigation ActionOptions
+// that can be appended to any post-action menu.
+// Each key is prefixed with NavPrefix so HandleCrossNav can identify them.
+func CrossNavOptions() []ActionOption {
+	return []ActionOption{
+		{Label: "📊 Compare: verify current state", Key: NavPrefix + "compare"},
+		{Label: "🔄 Sync: migrate data", Key: NavPrefix + "sync"},
+		{Label: "📦 Snap: manage snapshots", Key: NavPrefix + "snap"},
+	}
+}
+
+// IsCrossNav returns true if the action key is a cross-navigation transition.
+func IsCrossNav(key string) bool {
+	return strings.HasPrefix(key, NavPrefix)
+}
+
+// HandleCrossNav executes a cross-module navigation transition.
+// Returns true if the key was a nav: key and was handled, false otherwise.
+//
+// Server guard (B4): if a WorkSession exists, verifies that viper base_url
+// still matches the session's ServerURL. Warns on mismatch but proceeds.
+func HandleCrossNav(ctx context.Context, cmd *cobra.Command, key string) bool {
+	if !IsCrossNav(key) {
+		return false
+	}
+
+	// B4: server boundary check.
+	if s := SessionFromContext(ctx); s != nil && s.ServerURL != "" {
+		if current := viper.GetString("base_url"); current != "" && current != s.ServerURL {
+			fmt.Fprintf(os.Stderr,
+				"⚠ Server mismatch: session=%s, config=%s — using session server\n",
+				s.ServerURL, current)
+		}
+	}
+
+	target := strings.TrimPrefix(key, NavPrefix)
+	root := cmd.Root()
+	switch target {
+	case "compare":
+		_ = RunSubcommand(ctx, root, "compare", "all")
+	case "sync":
+		_ = RunSubcommand(ctx, root, "sync", "full")
+	case "snap":
+		_ = RunSubcommand(ctx, root, "snap", "list")
+	}
+	return true
+}

--- a/internal/interactive/cross_nav_test.go
+++ b/internal/interactive/cross_nav_test.go
@@ -1,0 +1,62 @@
+package interactive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCrossNavOptions(t *testing.T) {
+	opts := CrossNavOptions()
+	if len(opts) != 3 {
+		t.Fatalf("CrossNavOptions: want 3 options, got %d", len(opts))
+	}
+	wantKeys := []string{"nav:compare", "nav:sync", "nav:snap"}
+	for i, want := range wantKeys {
+		if opts[i].Key != want {
+			t.Errorf("opts[%d].Key = %q, want %q", i, opts[i].Key, want)
+		}
+	}
+}
+
+func TestIsCrossNav(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"nav:compare", true},
+		{"nav:sync", true},
+		{"nav:snap", true},
+		{"nav:unknown", true},
+		{"exit", false},
+		{"back", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsCrossNav(tt.key); got != tt.want {
+			t.Errorf("IsCrossNav(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestHandleCrossNav_NonNavKey(t *testing.T) {
+	ctx := context.Background()
+	cmd := &cobra.Command{Use: "test"}
+	if HandleCrossNav(ctx, cmd, "exit") {
+		t.Error("HandleCrossNav should return false for non-nav key")
+	}
+}
+
+func TestHandleCrossNav_UnknownTarget(t *testing.T) {
+	ctx := context.Background()
+	root := &cobra.Command{Use: "gotr"}
+	child := &cobra.Command{Use: "test"}
+	root.AddCommand(child)
+	child.SetContext(ctx)
+
+	// Unknown nav target — should return true (handled) but not panic.
+	if !HandleCrossNav(ctx, child, "nav:unknown") {
+		t.Error("HandleCrossNav should return true for nav: prefixed key")
+	}
+}

--- a/internal/interactive/group.go
+++ b/internal/interactive/group.go
@@ -1,0 +1,32 @@
+package interactive
+
+import "sort"
+
+// Group represents a named group of items.
+type Group[T any] struct {
+	Label string
+	Items []T
+}
+
+// GroupBy groups items using the provided key function.
+// Groups are returned sorted by label.
+func GroupBy[T any](items []T, keyFn func(T) string) []Group[T] {
+	idx := make(map[string]int)
+	var groups []Group[T]
+
+	for _, item := range items {
+		key := keyFn(item)
+		if i, ok := idx[key]; ok {
+			groups[i].Items = append(groups[i].Items, item)
+		} else {
+			idx[key] = len(groups)
+			groups = append(groups, Group[T]{Label: key, Items: []T{item}})
+		}
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Label < groups[j].Label
+	})
+
+	return groups
+}

--- a/internal/interactive/group_test.go
+++ b/internal/interactive/group_test.go
@@ -1,0 +1,39 @@
+package interactive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupBy_Basic(t *testing.T) {
+	items := []string{"apple", "avocado", "banana", "blueberry", "cherry"}
+	groups := GroupBy(items, func(s string) string {
+		return string(s[0]) // group by first letter
+	})
+
+	require.Len(t, groups, 3)
+
+	// Sorted: a, b, c
+	assert.Equal(t, "a", groups[0].Label)
+	assert.Equal(t, []string{"apple", "avocado"}, groups[0].Items)
+
+	assert.Equal(t, "b", groups[1].Label)
+	assert.Equal(t, []string{"banana", "blueberry"}, groups[1].Items)
+
+	assert.Equal(t, "c", groups[2].Label)
+	assert.Equal(t, []string{"cherry"}, groups[2].Items)
+}
+
+func TestGroupBy_Empty(t *testing.T) {
+	groups := GroupBy([]int{}, func(i int) string { return "x" })
+	assert.Empty(t, groups)
+}
+
+func TestGroupBy_SingleGroup(t *testing.T) {
+	groups := GroupBy([]int{1, 2, 3}, func(i int) string { return "all" })
+	require.Len(t, groups, 1)
+	assert.Equal(t, "all", groups[0].Label)
+	assert.Equal(t, []int{1, 2, 3}, groups[0].Items)
+}

--- a/internal/interactive/interactive.go
+++ b/internal/interactive/interactive.go
@@ -246,6 +246,121 @@ func SelectSharedStep(ctx context.Context, p Prompter, steps data.GetSharedSteps
 	return steps[idx].ID, nil
 }
 
+// SelectTest selects a test using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectTest(ctx context.Context, p Prompter, tests data.GetTestsResponse, prompt string, allowBack ...bool) (int64, error) {
+	if len(tests) == 0 {
+		return 0, fmt.Errorf("no tests found")
+	}
+
+	if prompt == "" {
+		prompt = "Select test:"
+	}
+
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Case", MinWidth: 6},
+		{Header: "Title"},
+	}
+	rows := make([][]string, len(tests))
+	for i, t := range tests {
+		rows[i] = []string{fmt.Sprintf("%d", t.ID), fmt.Sprintf("%d", t.CaseID), t.Title}
+	}
+	header, options := AlignedLabels(cols, rows)
+
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Header:    header,
+		Items:     options,
+		AllowBack: back,
+	})
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("failed to select test: %w", err)
+	}
+
+	return tests[idx].ID, nil
+}
+
+// SelectPlan selects a plan using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectPlan(ctx context.Context, p Prompter, plans data.GetPlansResponse, prompt string, allowBack ...bool) (int64, error) {
+	if len(plans) == 0 {
+		return 0, fmt.Errorf("no plans found")
+	}
+
+	if prompt == "" {
+		prompt = "Select plan:"
+	}
+
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(plans))
+	for i, plan := range plans {
+		rows[i] = []string{fmt.Sprintf("%d", plan.ID), plan.Name}
+	}
+	header, options := AlignedLabels(cols, rows)
+
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Header:    header,
+		Items:     options,
+		AllowBack: back,
+	})
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("failed to select plan: %w", err)
+	}
+
+	return plans[idx].ID, nil
+}
+
+// SelectPlanEntry selects a plan entry using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectPlanEntry(ctx context.Context, p Prompter, entries []data.PlanEntry, prompt string, allowBack ...bool) (string, error) {
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no plan entries found")
+	}
+
+	if prompt == "" {
+		prompt = "Select plan entry:"
+	}
+
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(entries))
+	for i, e := range entries {
+		rows[i] = []string{e.ID, e.Name}
+	}
+	header, options := AlignedLabels(cols, rows)
+
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Header:    header,
+		Items:     options,
+		AllowBack: back,
+	})
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return "", err
+		}
+		return "", fmt.Errorf("failed to select plan entry: %w", err)
+	}
+
+	return entries[idx].ID, nil
+}
+
 // SelectSuiteForProject fetches suites for a project and selects one using the prompter.
 // Pass allowBack=true to show "← Back" in addition to "✕ Exit".
 func SelectSuiteForProject(ctx context.Context, p Prompter, cli client.ClientInterface, projectID int64, prompt string, allowBack ...bool) (int64, error) {

--- a/internal/interactive/interactive.go
+++ b/internal/interactive/interactive.go
@@ -361,6 +361,44 @@ func SelectPlanEntry(ctx context.Context, p Prompter, entries []data.PlanEntry, 
 	return entries[idx].ID, nil
 }
 
+// SelectDataset selects a dataset using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectDataset(ctx context.Context, p Prompter, datasets data.GetDatasetsResponse, prompt string, allowBack ...bool) (int64, error) {
+	if len(datasets) == 0 {
+		return 0, fmt.Errorf("no datasets found")
+	}
+
+	if prompt == "" {
+		prompt = "Select dataset:"
+	}
+
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(datasets))
+	for i, ds := range datasets {
+		rows[i] = []string{fmt.Sprintf("%d", ds.ID), ds.Name}
+	}
+	header, options := AlignedLabels(cols, rows)
+
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Header:    header,
+		Items:     options,
+		AllowBack: back,
+	})
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("failed to select dataset: %w", err)
+	}
+
+	return datasets[idx].ID, nil
+}
+
 // SelectSuiteForProject fetches suites for a project and selects one using the prompter.
 // Pass allowBack=true to show "← Back" in addition to "✕ Exit".
 func SelectSuiteForProject(ctx context.Context, p Prompter, cli client.ClientInterface, projectID int64, prompt string, allowBack ...bool) (int64, error) {

--- a/internal/interactive/interactive.go
+++ b/internal/interactive/interactive.go
@@ -8,8 +8,9 @@ import (
 	"github.com/Korrnals/gotr/internal/models/data"
 )
 
-// SelectProject selects a project using unified prompter.
-func SelectProject(ctx context.Context, p Prompter, httpClient client.ClientInterface, prompt string) (int64, error) {
+// SelectProject selects a project using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectProject(ctx context.Context, p Prompter, httpClient client.ClientInterface, prompt string, allowBack ...bool) (int64, error) {
 	projects, err := httpClient.GetProjects(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get projects list: %w", err)
@@ -28,17 +29,25 @@ func SelectProject(ctx context.Context, p Prompter, httpClient client.ClientInte
 		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, p.ID, p.Name))
 	}
 
-	idx, _, err := p.Select(prompt, options)
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Items:     options,
+		AllowBack: back,
+	})
 	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
 		return 0, fmt.Errorf("failed to select project: %w", err)
 	}
 
 	return projects[idx].ID, nil
 }
 
-// SelectSuite selects a suite using unified prompter.
-func SelectSuite(ctx context.Context, p Prompter, suites data.GetSuitesResponse, prompt string) (int64, error) {
-	_ = ctx
+// SelectSuite selects a suite using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectSuite(ctx context.Context, p Prompter, suites data.GetSuitesResponse, prompt string, allowBack ...bool) (int64, error) {
 	if len(suites) == 0 {
 		return 0, fmt.Errorf("no suites found")
 	}
@@ -53,17 +62,25 @@ func SelectSuite(ctx context.Context, p Prompter, suites data.GetSuitesResponse,
 		options = append(options, line)
 	}
 
-	idx, _, err := p.Select(prompt, options)
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Items:     options,
+		AllowBack: back,
+	})
 	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
 		return 0, fmt.Errorf("failed to select suite: %w", err)
 	}
 
 	return suites[idx].ID, nil
 }
 
-// SelectRun selects a run using unified prompter.
-func SelectRun(ctx context.Context, p Prompter, runs data.GetRunsResponse, prompt string) (int64, error) {
-	_ = ctx
+// SelectRun selects a run using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectRun(ctx context.Context, p Prompter, runs data.GetRunsResponse, prompt string, allowBack ...bool) (int64, error) {
 	if len(runs) == 0 {
 		return 0, fmt.Errorf("no runs found")
 	}
@@ -82,17 +99,25 @@ func SelectRun(ctx context.Context, p Prompter, runs data.GetRunsResponse, promp
 		options = append(options, line)
 	}
 
-	idx, _, err := p.Select(prompt, options)
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Items:     options,
+		AllowBack: back,
+	})
 	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
 		return 0, fmt.Errorf("failed to select run: %w", err)
 	}
 
 	return runs[idx].ID, nil
 }
 
-// SelectSection selects a section using unified prompter.
-func SelectSection(ctx context.Context, p Prompter, sections data.GetSectionsResponse, prompt string) (int64, error) {
-	_ = ctx
+// SelectSection selects a section using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectSection(ctx context.Context, p Prompter, sections data.GetSectionsResponse, prompt string, allowBack ...bool) (int64, error) {
 	if len(sections) == 0 {
 		return 0, fmt.Errorf("no sections found")
 	}
@@ -107,8 +132,16 @@ func SelectSection(ctx context.Context, p Prompter, sections data.GetSectionsRes
 		options = append(options, line)
 	}
 
-	idx, _, err := p.Select(prompt, options)
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Items:     options,
+		AllowBack: back,
+	})
 	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
 		return 0, fmt.Errorf("failed to select section: %w", err)
 	}
 
@@ -116,10 +149,11 @@ func SelectSection(ctx context.Context, p Prompter, sections data.GetSectionsRes
 }
 
 // SelectSuiteForProject fetches suites for a project and selects one using the prompter.
-func SelectSuiteForProject(ctx context.Context, p Prompter, cli client.ClientInterface, projectID int64, prompt string) (int64, error) {
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectSuiteForProject(ctx context.Context, p Prompter, cli client.ClientInterface, projectID int64, prompt string, allowBack ...bool) (int64, error) {
 	suites, err := cli.GetSuites(ctx, projectID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get suites for project %d: %w", projectID, err)
 	}
-	return SelectSuite(ctx, p, suites, prompt)
+	return SelectSuite(ctx, p, suites, prompt, allowBack...)
 }

--- a/internal/interactive/interactive.go
+++ b/internal/interactive/interactive.go
@@ -24,14 +24,20 @@ func SelectProject(ctx context.Context, p Prompter, httpClient client.ClientInte
 		prompt = "Select project:"
 	}
 
-	options := make([]string, 0, len(projects))
-	for i, p := range projects {
-		options = append(options, fmt.Sprintf("[%d] ID: %d | %s", i+1, p.ID, p.Name))
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
 	}
+	rows := make([][]string, len(projects))
+	for i, proj := range projects {
+		rows[i] = []string{fmt.Sprintf("%d", proj.ID), proj.Name}
+	}
+	header, options := AlignedLabels(cols, rows)
 
 	back := len(allowBack) > 0 && allowBack[0]
 	idx, err := Browse(ctx, p, BrowseConfig{
 		Prompt:    prompt,
+		Header:    header,
 		Items:     options,
 		AllowBack: back,
 	})
@@ -56,15 +62,20 @@ func SelectSuite(ctx context.Context, p Prompter, suites data.GetSuitesResponse,
 		prompt = "Select suite:"
 	}
 
-	options := make([]string, 0, len(suites))
-	for i, suite := range suites {
-		line := fmt.Sprintf("[%d] ID: %d | %s", i+1, suite.ID, suite.Name)
-		options = append(options, line)
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
 	}
+	rows := make([][]string, len(suites))
+	for i, s := range suites {
+		rows[i] = []string{fmt.Sprintf("%d", s.ID), s.Name}
+	}
+	header, options := AlignedLabels(cols, rows)
 
 	back := len(allowBack) > 0 && allowBack[0]
 	idx, err := Browse(ctx, p, BrowseConfig{
 		Prompt:    prompt,
+		Header:    header,
 		Items:     options,
 		AllowBack: back,
 	})
@@ -89,19 +100,25 @@ func SelectRun(ctx context.Context, p Prompter, runs data.GetRunsResponse, promp
 		prompt = "Select run:"
 	}
 
-	options := make([]string, 0, len(runs))
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Status", MinWidth: 10},
+		{Header: "Name"},
+	}
+	rows := make([][]string, len(runs))
 	for i, run := range runs {
 		status := "active"
 		if run.IsCompleted {
 			status = "completed"
 		}
-		line := fmt.Sprintf("[%d] (%s) ID: %d | %s", i+1, status, run.ID, run.Name)
-		options = append(options, line)
+		rows[i] = []string{fmt.Sprintf("%d", run.ID), status, run.Name}
 	}
+	header, options := AlignedLabels(cols, rows)
 
 	back := len(allowBack) > 0 && allowBack[0]
 	idx, err := Browse(ctx, p, BrowseConfig{
 		Prompt:    prompt,
+		Header:    header,
 		Items:     options,
 		AllowBack: back,
 	})
@@ -126,15 +143,20 @@ func SelectSection(ctx context.Context, p Prompter, sections data.GetSectionsRes
 		prompt = "Select section:"
 	}
 
-	options := make([]string, 0, len(sections))
-	for i, section := range sections {
-		line := fmt.Sprintf("[%d] ID: %d | %s", i+1, section.ID, section.Name)
-		options = append(options, line)
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Name"},
 	}
+	rows := make([][]string, len(sections))
+	for i, sec := range sections {
+		rows[i] = []string{fmt.Sprintf("%d", sec.ID), sec.Name}
+	}
+	header, options := AlignedLabels(cols, rows)
 
 	back := len(allowBack) > 0 && allowBack[0]
 	idx, err := Browse(ctx, p, BrowseConfig{
 		Prompt:    prompt,
+		Header:    header,
 		Items:     options,
 		AllowBack: back,
 	})
@@ -146,6 +168,82 @@ func SelectSection(ctx context.Context, p Prompter, sections data.GetSectionsRes
 	}
 
 	return sections[idx].ID, nil
+}
+
+// SelectCase selects a case using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectCase(ctx context.Context, p Prompter, cases data.GetCasesResponse, prompt string, allowBack ...bool) (int64, error) {
+	if len(cases) == 0 {
+		return 0, fmt.Errorf("no cases found")
+	}
+
+	if prompt == "" {
+		prompt = "Select case:"
+	}
+
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Title"},
+	}
+	rows := make([][]string, len(cases))
+	for i, c := range cases {
+		rows[i] = []string{fmt.Sprintf("%d", c.ID), c.Title}
+	}
+	header, options := AlignedLabels(cols, rows)
+
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Header:    header,
+		Items:     options,
+		AllowBack: back,
+	})
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("failed to select case: %w", err)
+	}
+
+	return cases[idx].ID, nil
+}
+
+// SelectSharedStep selects a shared step using unified prompter with Browse navigation.
+// Pass allowBack=true to show "← Back" in addition to "✕ Exit".
+func SelectSharedStep(ctx context.Context, p Prompter, steps data.GetSharedStepsResponse, prompt string, allowBack ...bool) (int64, error) {
+	if len(steps) == 0 {
+		return 0, fmt.Errorf("no shared steps found")
+	}
+
+	if prompt == "" {
+		prompt = "Select shared step:"
+	}
+
+	cols := []Column{
+		{Header: "ID", MinWidth: 6},
+		{Header: "Title"},
+	}
+	rows := make([][]string, len(steps))
+	for i, s := range steps {
+		rows[i] = []string{fmt.Sprintf("%d", s.ID), s.Title}
+	}
+	header, options := AlignedLabels(cols, rows)
+
+	back := len(allowBack) > 0 && allowBack[0]
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Header:    header,
+		Items:     options,
+		AllowBack: back,
+	})
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("failed to select shared step: %w", err)
+	}
+
+	return steps[idx].ID, nil
 }
 
 // SelectSuiteForProject fetches suites for a project and selects one using the prompter.

--- a/internal/interactive/interactive_test.go
+++ b/internal/interactive/interactive_test.go
@@ -95,10 +95,10 @@ func TestSelectRun_DefaultPromptAndCompletedStatus(t *testing.T) {
 	id, err := SelectRun(context.Background(), p, runs, "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(22), id)
-	assert.Equal(t, "Select run:", p.lastMessage)
+	assert.Contains(t, p.lastMessage, "Select run:")
 	require.Len(t, p.lastOptions, 3) // Exit + 2 runs
-	assert.Contains(t, p.lastOptions[1], "(active)")
-	assert.Contains(t, p.lastOptions[2], "(completed)")
+	assert.Contains(t, p.lastOptions[1], "active")
+	assert.Contains(t, p.lastOptions[2], "completed")
 }
 
 func TestSelectSuiteForProject_Branches(t *testing.T) {
@@ -180,7 +180,7 @@ func TestSelectSuiteAndSection_DefaultPromptSuccess(t *testing.T) {
 		id, err := SelectSuite(ctx, p, data.GetSuitesResponse{{ID: 101, Name: "Suite"}}, "")
 		require.NoError(t, err)
 		assert.Equal(t, int64(101), id)
-		assert.Equal(t, "Select suite:", p.lastMessage)
+		assert.Contains(t, p.lastMessage, "Select suite:")
 	})
 
 	t.Run("SelectSection default prompt", func(t *testing.T) {
@@ -188,6 +188,106 @@ func TestSelectSuiteAndSection_DefaultPromptSuccess(t *testing.T) {
 		id, err := SelectSection(ctx, p, data.GetSectionsResponse{{ID: 202, Name: "Section"}}, "")
 		require.NoError(t, err)
 		assert.Equal(t, int64(202), id)
-		assert.Equal(t, "Select section:", p.lastMessage)
+		assert.Contains(t, p.lastMessage, "Select section:")
+	})
+}
+
+func TestSelectCase(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success selects correct case", func(t *testing.T) {
+		cases := data.GetCasesResponse{
+			{ID: 100, Title: "Case A"},
+			{ID: 200, Title: "Case B"},
+		}
+		p := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 1})
+		id, err := SelectCase(ctx, p, cases, "")
+		require.NoError(t, err)
+		assert.Equal(t, int64(200), id)
+	})
+
+	t.Run("empty list returns error", func(t *testing.T) {
+		p := NewMockPrompter()
+		id, err := SelectCase(ctx, p, data.GetCasesResponse{}, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no cases found")
+		assert.Zero(t, id)
+	})
+
+	t.Run("select error propagates", func(t *testing.T) {
+		cases := data.GetCasesResponse{{ID: 1, Title: "C"}}
+		p := NewNonInteractivePrompter()
+		id, err := SelectCase(ctx, p, cases, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to select case")
+		assert.Zero(t, id)
+	})
+
+	t.Run("custom prompt is used", func(t *testing.T) {
+		cases := data.GetCasesResponse{{ID: 1, Title: "C"}}
+		p := &spyPrompter{idx: 1} // +1 for Exit
+		id, err := SelectCase(ctx, p, cases, "Pick a case:")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), id)
+		assert.Contains(t, p.lastMessage, "Pick a case:")
+	})
+
+	t.Run("exit returns ErrExit", func(t *testing.T) {
+		cases := data.GetCasesResponse{{ID: 1, Title: "C"}}
+		p := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0, Raw: true}) // Exit
+		_, err := SelectCase(ctx, p, cases, "")
+		assert.True(t, IsExit(err))
+	})
+
+	t.Run("aligned labels have header", func(t *testing.T) {
+		cases := data.GetCasesResponse{
+			{ID: 100, Title: "Login Test"},
+			{ID: 200, Title: "Logout Test"},
+		}
+		p := &spyPrompter{idx: 1} // +1 for Exit
+		_, err := SelectCase(ctx, p, cases, "")
+		require.NoError(t, err)
+		assert.Contains(t, p.lastMessage, "ID")
+		assert.Contains(t, p.lastMessage, "Title")
+	})
+}
+
+func TestSelectSharedStep(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success selects correct step", func(t *testing.T) {
+		steps := data.GetSharedStepsResponse{
+			{ID: 555, Title: "Step A"},
+			{ID: 666, Title: "Step B"},
+		}
+		p := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0})
+		id, err := SelectSharedStep(ctx, p, steps, "")
+		require.NoError(t, err)
+		assert.Equal(t, int64(555), id)
+	})
+
+	t.Run("empty list returns error", func(t *testing.T) {
+		p := NewMockPrompter()
+		id, err := SelectSharedStep(ctx, p, data.GetSharedStepsResponse{}, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no shared steps found")
+		assert.Zero(t, id)
+	})
+
+	t.Run("select error propagates", func(t *testing.T) {
+		steps := data.GetSharedStepsResponse{{ID: 1, Title: "S"}}
+		p := NewNonInteractivePrompter()
+		id, err := SelectSharedStep(ctx, p, steps, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to select shared step")
+		assert.Zero(t, id)
+	})
+
+	t.Run("default prompt", func(t *testing.T) {
+		steps := data.GetSharedStepsResponse{{ID: 1, Title: "S"}}
+		p := &spyPrompter{idx: 1} // +1 for Exit
+		_, err := SelectSharedStep(ctx, p, steps, "")
+		require.NoError(t, err)
+		assert.Contains(t, p.lastMessage, "Select shared step:")
 	})
 }

--- a/internal/interactive/interactive_test.go
+++ b/internal/interactive/interactive_test.go
@@ -79,13 +79,14 @@ func TestSelectProject_ErrorBranches(t *testing.T) {
 
 		_, err := SelectProject(ctx, p, cli, "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to select project")
-		assert.Equal(t, "Select project:", p.lastMessage)
+		assert.Contains(t, err.Error(), "select failed")
 	})
 }
 
 func TestSelectRun_DefaultPromptAndCompletedStatus(t *testing.T) {
-	p := &spyPrompter{idx: 1}
+	// Browse options: [✕ Exit, (active) Active Run, (completed) Closed Run]
+	// Index 2 selects "Closed Run"
+	p := &spyPrompter{idx: 2}
 	runs := data.GetRunsResponse{
 		{ID: 11, Name: "Active Run", IsCompleted: false},
 		{ID: 22, Name: "Closed Run", IsCompleted: true},
@@ -95,9 +96,9 @@ func TestSelectRun_DefaultPromptAndCompletedStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(22), id)
 	assert.Equal(t, "Select run:", p.lastMessage)
-	require.Len(t, p.lastOptions, 2)
-	assert.Contains(t, p.lastOptions[0], "(active)")
-	assert.Contains(t, p.lastOptions[1], "(completed)")
+	require.Len(t, p.lastOptions, 3) // Exit + 2 runs
+	assert.Contains(t, p.lastOptions[1], "(active)")
+	assert.Contains(t, p.lastOptions[2], "(completed)")
 }
 
 func TestSelectSuiteForProject_Branches(t *testing.T) {
@@ -141,8 +142,7 @@ func TestSelectSuite_Run_Section_ErrorBranches(t *testing.T) {
 		p := &spyPrompter{err: errors.New("select fail")}
 		_, err := SelectSuite(ctx, p, data.GetSuitesResponse{{ID: 1, Name: "S"}}, "Custom suite prompt")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to select suite")
-		assert.Equal(t, "Custom suite prompt", p.lastMessage)
+		assert.Contains(t, err.Error(), "select fail")
 	})
 
 	t.Run("SelectRun no runs", func(t *testing.T) {
@@ -155,8 +155,7 @@ func TestSelectSuite_Run_Section_ErrorBranches(t *testing.T) {
 		p := &spyPrompter{err: errors.New("select fail")}
 		_, err := SelectRun(ctx, p, data.GetRunsResponse{{ID: 2, Name: "R"}}, "Custom run prompt")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to select run")
-		assert.Equal(t, "Custom run prompt", p.lastMessage)
+		assert.Contains(t, err.Error(), "select fail")
 	})
 
 	t.Run("SelectSection no sections", func(t *testing.T) {
@@ -169,8 +168,7 @@ func TestSelectSuite_Run_Section_ErrorBranches(t *testing.T) {
 		p := &spyPrompter{err: errors.New("select fail")}
 		_, err := SelectSection(ctx, p, data.GetSectionsResponse{{ID: 3, Name: "Sec"}}, "Custom section prompt")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to select section")
-		assert.Equal(t, "Custom section prompt", p.lastMessage)
+		assert.Contains(t, err.Error(), "select fail")
 	})
 }
 
@@ -178,7 +176,7 @@ func TestSelectSuiteAndSection_DefaultPromptSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("SelectSuite default prompt", func(t *testing.T) {
-		p := &spyPrompter{idx: 0}
+		p := &spyPrompter{idx: 1} // +1 for Exit option
 		id, err := SelectSuite(ctx, p, data.GetSuitesResponse{{ID: 101, Name: "Suite"}}, "")
 		require.NoError(t, err)
 		assert.Equal(t, int64(101), id)
@@ -186,7 +184,7 @@ func TestSelectSuiteAndSection_DefaultPromptSuccess(t *testing.T) {
 	})
 
 	t.Run("SelectSection default prompt", func(t *testing.T) {
-		p := &spyPrompter{idx: 0}
+		p := &spyPrompter{idx: 1} // +1 for Exit option
 		id, err := SelectSection(ctx, p, data.GetSectionsResponse{{ID: 202, Name: "Section"}}, "")
 		require.NoError(t, err)
 		assert.Equal(t, int64(202), id)

--- a/internal/interactive/mock.go
+++ b/internal/interactive/mock.go
@@ -6,6 +6,11 @@ import "fmt"
 type SelectResponse struct {
 	Index int
 	Value string
+	// Raw disables auto-adjustment for Browse navigation options.
+	// When false (default), the mock automatically skips "← Back" / "✕ Exit"
+	// options prepended by Browse, so Index 0 always means the first real item.
+	// Set to true when testing navigation option selection explicitly.
+	Raw bool
 }
 
 // MockPrompter is deterministic prompter for unit tests.
@@ -67,6 +72,8 @@ func (m *MockPrompter) Confirm(message string, def bool) (bool, error) {
 }
 
 // Select returns next queued select response.
+// When the response has Raw=false (default), the index is auto-adjusted
+// to skip Browse navigation options (← Back, ✕ Exit) at the top of the list.
 func (m *MockPrompter) Select(message string, options []string) (idx int, value string, err error) {
 	if len(options) == 0 {
 		return 0, "", fmt.Errorf("select options list is empty")
@@ -79,16 +86,36 @@ func (m *MockPrompter) Select(message string, options []string) (idx int, value 
 	response := m.selects[m.selectPos]
 	m.selectPos++
 
-	if response.Index < 0 || response.Index >= len(options) {
-		return 0, "", fmt.Errorf("mock select index out of range: %d", response.Index)
+	actualIdx := response.Index
+	if !response.Raw {
+		actualIdx += countNavPrefix(options)
+	}
+
+	if actualIdx < 0 || actualIdx >= len(options) {
+		return 0, "", fmt.Errorf("mock select index out of range: %d (raw=%d, nav=%d, opts=%d)",
+			actualIdx, response.Index, countNavPrefix(options), len(options))
 	}
 
 	value = response.Value
 	if value == "" {
-		value = options[response.Index]
+		value = options[actualIdx]
 	}
 
-	return response.Index, value, nil
+	return actualIdx, value, nil
+}
+
+// countNavPrefix counts Browse navigation options (← Back, ✕ Exit) at the
+// start of the option list.
+func countNavPrefix(options []string) int {
+	n := 0
+	for _, opt := range options {
+		if opt == OptBack || opt == OptExit {
+			n++
+		} else {
+			break
+		}
+	}
+	return n
 }
 
 // MultilineInput behaves the same as Input for test purposes.

--- a/internal/interactive/mutation_action.go
+++ b/internal/interactive/mutation_action.go
@@ -1,0 +1,31 @@
+package interactive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// MutationPostAction shows a minimal post-action menu after a data mutation.
+// Options: Exit (default), View snapshots.
+// Silently returns when not in interactive mode or prompter is unavailable.
+func MutationPostAction(ctx context.Context, cmd *cobra.Command) {
+	if !HasPrompterInContext(ctx) || IsNonInteractive(ctx) {
+		return
+	}
+
+	p := PrompterFromContext(ctx)
+	key, err := ActionMenu(ctx, p, "What next?", []ActionOption{
+		{Label: OptExit, Key: "exit"},
+		{Label: "📦 View snapshots", Key: "snap"},
+	})
+	if err != nil || key == "exit" {
+		return
+	}
+	if key == "snap" {
+		fmt.Println()
+		_ = RunSubcommand(ctx, cmd.Root(), "snap", "list")
+		fmt.Println()
+	}
+}

--- a/internal/interactive/nav_dispatch.go
+++ b/internal/interactive/nav_dispatch.go
@@ -1,0 +1,55 @@
+package interactive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NavTarget identifies a cross-navigation destination.
+type NavTarget struct {
+	Label string   // Display label in the menu.
+	Path  []string // Cobra command path (e.g. ["compare", "all"]).
+}
+
+// Standard navigation targets used across post-action menus.
+var (
+	NavCompareAll = NavTarget{Label: "📊 Compare: verify current state", Path: []string{"compare", "all"}}
+	NavSyncFull   = NavTarget{Label: "🔄 Sync: migrate data", Path: []string{"sync", "full"}}
+	NavSnapList   = NavTarget{Label: "📦 Snap: manage snapshots", Path: []string{"snap", "list"}}
+)
+
+// NavigateMenu shows a navigation sub-menu with the given targets and
+// dispatches the selected command via RunSubcommand.
+// Returns nil on successful dispatch or exit; returns ErrGoBack when the user
+// chooses "← Back".
+func NavigateMenu(ctx context.Context, cmd *cobra.Command, prompt string, targets []NavTarget) error {
+	p := PrompterFromContext(ctx)
+
+	labels := make([]string, len(targets))
+	for i, t := range targets {
+		labels[i] = t.label()
+	}
+
+	idx, err := Browse(ctx, p, BrowseConfig{
+		Prompt:    prompt,
+		Items:     labels,
+		AllowBack: true,
+	})
+	if err != nil {
+		return err // ErrGoBack or ErrExit
+	}
+
+	target := targets[idx]
+	fmt.Println()
+	if runErr := RunSubcommand(ctx, cmd.Root(), target.Path...); runErr != nil {
+		return runErr
+	}
+	fmt.Println()
+	return nil
+}
+
+func (t NavTarget) label() string {
+	return t.Label
+}

--- a/internal/interactive/nav_dispatch_test.go
+++ b/internal/interactive/nav_dispatch_test.go
@@ -1,0 +1,51 @@
+package interactive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNavigateMenu_BackReturnsGoBack(t *testing.T) {
+	// Select "← Back" (index 0 with raw=true)
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0, Raw: true})
+	ctx := WithPrompter(context.Background(), mock)
+
+	root := &cobra.Command{Use: "root"}
+	root.SetContext(ctx)
+
+	err := NavigateMenu(ctx, root, "Navigate:", []NavTarget{NavCompareAll})
+	if !IsGoBack(err) {
+		t.Errorf("expected ErrGoBack, got %v", err)
+	}
+}
+
+func TestNavigateMenu_SelectTarget(t *testing.T) {
+	// Build a minimal Cobra tree with a runnable "compare all".
+	root := &cobra.Command{Use: "root"}
+	compare := &cobra.Command{Use: "compare"}
+	ran := false
+	allCmd := &cobra.Command{
+		Use: "all",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+	compare.AddCommand(allCmd)
+	root.AddCommand(compare)
+
+	// Select first data item (index 0) — Browse adds "← Back" at top, so raw index = 1.
+	mock := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 0})
+	ctx := WithPrompter(context.Background(), mock)
+	root.SetContext(ctx)
+
+	err := NavigateMenu(ctx, root, "Navigate:", []NavTarget{NavCompareAll})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ran {
+		t.Error("expected compare all to run")
+	}
+}

--- a/internal/interactive/navigation.go
+++ b/internal/interactive/navigation.go
@@ -1,6 +1,13 @@
 package interactive
 
-import "errors"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 // Navigation sentinel errors for multi-level interactive flows.
 var (
@@ -25,4 +32,32 @@ func IsGoBack(err error) bool {
 // IsExit returns true if the error is an exit sentinel.
 func IsExit(err error) bool {
 	return errors.Is(err, ErrExit)
+}
+
+// FindSubcommand locates a subcommand by path via Cobra tree traversal.
+// Returns an error if the command is not found.
+func FindSubcommand(root *cobra.Command, path ...string) (*cobra.Command, error) {
+	target, _, err := root.Find(path)
+	if err != nil || target == nil || target.Name() == root.Name() {
+		return nil, fmt.Errorf("could not find 'gotr %s' command", strings.Join(path, " "))
+	}
+	return target, nil
+}
+
+// RunSubcommand finds a subcommand by path, propagates context, and runs it.
+// GoBack/Exit sentinel errors are absorbed (return nil).
+// Real execution errors are returned as-is.
+func RunSubcommand(ctx context.Context, root *cobra.Command, path ...string) error {
+	target, err := FindSubcommand(root, path...)
+	if err != nil {
+		return err
+	}
+	target.SetContext(ctx)
+	if err := target.RunE(target, nil); err != nil {
+		if IsGoBack(err) || IsExit(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/interactive/navigation.go
+++ b/internal/interactive/navigation.go
@@ -1,0 +1,28 @@
+package interactive
+
+import "errors"
+
+// Navigation sentinel errors for multi-level interactive flows.
+var (
+	// ErrGoBack signals the user chose "← Back" to return to the previous level.
+	ErrGoBack = errors.New("go back")
+
+	// ErrExit signals the user chose "✕ Exit" to leave the interactive flow.
+	ErrExit = errors.New("exit")
+)
+
+// Navigation option labels (consistent across all commands).
+const (
+	OptBack = "← Back"
+	OptExit = "✕ Exit"
+)
+
+// IsGoBack returns true if the error is a back-navigation sentinel.
+func IsGoBack(err error) bool {
+	return errors.Is(err, ErrGoBack)
+}
+
+// IsExit returns true if the error is an exit sentinel.
+func IsExit(err error) bool {
+	return errors.Is(err, ErrExit)
+}

--- a/internal/interactive/navigation_test.go
+++ b/internal/interactive/navigation_test.go
@@ -1,9 +1,13 @@
 package interactive
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsGoBack(t *testing.T) {
@@ -16,4 +20,89 @@ func TestIsExit(t *testing.T) {
 	assert.True(t, IsExit(ErrExit))
 	assert.False(t, IsExit(ErrGoBack))
 	assert.False(t, IsExit(nil))
+}
+
+func TestFindSubcommand_Found(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{Use: "child"}
+	grandchild := &cobra.Command{Use: "grand"}
+	child.AddCommand(grandchild)
+	root.AddCommand(child)
+
+	cmd, err := FindSubcommand(root, "child", "grand")
+	require.NoError(t, err)
+	assert.Equal(t, "grand", cmd.Name())
+}
+
+func TestFindSubcommand_NotFound(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	_, err := FindSubcommand(root, "nonexistent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not find 'gotr nonexistent'")
+}
+
+func TestRunSubcommand_Success(t *testing.T) {
+	called := false
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			called = true
+			return nil
+		},
+	}
+	root.AddCommand(child)
+
+	err := RunSubcommand(context.Background(), root, "child")
+	assert.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestRunSubcommand_GoBackAbsorbed(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ErrGoBack
+		},
+	}
+	root.AddCommand(child)
+
+	err := RunSubcommand(context.Background(), root, "child")
+	assert.NoError(t, err, "GoBack should be absorbed")
+}
+
+func TestRunSubcommand_ExitAbsorbed(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ErrExit
+		},
+	}
+	root.AddCommand(child)
+
+	err := RunSubcommand(context.Background(), root, "child")
+	assert.NoError(t, err, "Exit should be absorbed")
+}
+
+func TestRunSubcommand_RealError(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("boom")
+		},
+	}
+	root.AddCommand(child)
+
+	err := RunSubcommand(context.Background(), root, "child")
+	assert.EqualError(t, err, "boom")
+}
+
+func TestRunSubcommand_NotFound(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	err := RunSubcommand(context.Background(), root, "missing")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not find")
 }

--- a/internal/interactive/navigation_test.go
+++ b/internal/interactive/navigation_test.go
@@ -1,0 +1,19 @@
+package interactive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGoBack(t *testing.T) {
+	assert.True(t, IsGoBack(ErrGoBack))
+	assert.False(t, IsGoBack(ErrExit))
+	assert.False(t, IsGoBack(nil))
+}
+
+func TestIsExit(t *testing.T) {
+	assert.True(t, IsExit(ErrExit))
+	assert.False(t, IsExit(ErrGoBack))
+	assert.False(t, IsExit(nil))
+}

--- a/internal/interactive/pager.go
+++ b/internal/interactive/pager.go
@@ -68,10 +68,12 @@ func Pager(cfg PagerConfig) error {
 
 	for {
 		// Clear screen and render current page.
+		// In raw mode \n is just LF (move down); we need \r\n (CR+LF)
+		// to avoid the "staircase" / diagonal rendering artifact.
 		fmt.Print("\033[2J\033[H") // clear + move to top
 
 		if cfg.Header != "" {
-			fmt.Println(cfg.Header)
+			fmt.Print(cfg.Header + "\r\n")
 		}
 
 		start := page * contentPerPage
@@ -81,11 +83,11 @@ func Pager(cfg PagerConfig) error {
 		}
 
 		for _, line := range cfg.Lines[start:end] {
-			fmt.Println(line)
+			fmt.Print(line + "\r\n")
 		}
 
 		// Status bar.
-		fmt.Printf("\n\033[7m Page %d/%d │ [Enter/Space] next │ [b] prev │ [q] quit \033[0m", page+1, totalPages)
+		fmt.Printf("\r\n\033[7m Page %d/%d │ [Enter/Space] next │ [b] prev │ [q] quit \033[0m", page+1, totalPages)
 
 		// Read single key.
 		buf := make([]byte, 3)
@@ -139,6 +141,15 @@ func detectPageSize() int {
 		return 24 // safe default
 	}
 	return h
+}
+
+// TerminalWidth returns the current terminal width or a safe default.
+func TerminalWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w < 40 {
+		return 120 // safe default
+	}
+	return w
 }
 
 func pagerFallback(cfg PagerConfig) error {

--- a/internal/interactive/pager.go
+++ b/internal/interactive/pager.go
@@ -1,0 +1,152 @@
+package interactive
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// PagerConfig configures the interactive pager.
+type PagerConfig struct {
+	// Lines are the content lines to paginate.
+	Lines []string
+	// Header is printed at the top of every page (optional).
+	Header string
+	// PageSize overrides the number of lines per page.
+	// If 0, auto-detects from terminal height.
+	PageSize int
+}
+
+// Pager displays lines page by page in the terminal.
+// Navigation: Enter/Space = next page, b = previous page, q = quit.
+// If the output fits in one page, prints directly without pagination.
+func Pager(cfg PagerConfig) error {
+	if len(cfg.Lines) == 0 {
+		return nil
+	}
+
+	pageSize := cfg.PageSize
+	if pageSize <= 0 {
+		pageSize = detectPageSize()
+	}
+
+	// Reserve space for header + status line.
+	reservedLines := 2
+	if cfg.Header != "" {
+		reservedLines += strings.Count(cfg.Header, "\n") + 1
+	}
+	contentPerPage := pageSize - reservedLines
+	if contentPerPage < 5 {
+		contentPerPage = 5
+	}
+
+	totalPages := (len(cfg.Lines) + contentPerPage - 1) / contentPerPage
+
+	// If everything fits in one page — just print.
+	if totalPages <= 1 {
+		if cfg.Header != "" {
+			fmt.Println(cfg.Header)
+		}
+		for _, line := range cfg.Lines {
+			fmt.Println(line)
+		}
+		return nil
+	}
+
+	// Switch terminal to raw mode for single-key input.
+	fd := int(os.Stdin.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		// Fallback: print everything.
+		return pagerFallback(cfg)
+	}
+	defer term.Restore(fd, oldState)
+
+	page := 0
+
+	for {
+		// Clear screen and render current page.
+		fmt.Print("\033[2J\033[H") // clear + move to top
+
+		if cfg.Header != "" {
+			fmt.Println(cfg.Header)
+		}
+
+		start := page * contentPerPage
+		end := start + contentPerPage
+		if end > len(cfg.Lines) {
+			end = len(cfg.Lines)
+		}
+
+		for _, line := range cfg.Lines[start:end] {
+			fmt.Println(line)
+		}
+
+		// Status bar.
+		fmt.Printf("\n\033[7m Page %d/%d │ [Enter/Space] next │ [b] prev │ [q] quit \033[0m", page+1, totalPages)
+
+		// Read single key.
+		buf := make([]byte, 3)
+		n, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+
+		switch {
+		case n == 1 && (buf[0] == 'q' || buf[0] == 'Q'):
+			fmt.Print("\033[2J\033[H") // clear before exit
+			return nil
+		case n == 1 && (buf[0] == 'b' || buf[0] == 'B'):
+			if page > 0 {
+				page--
+			}
+		case n == 1 && (buf[0] == '\r' || buf[0] == '\n' || buf[0] == ' '):
+			if page < totalPages-1 {
+				page++
+			}
+		case n == 1 && buf[0] == 3: // Ctrl+C
+			fmt.Print("\033[2J\033[H")
+			return nil
+		// Arrow keys: ESC [ A/B
+		case n == 3 && buf[0] == 27 && buf[1] == '[' && buf[2] == 'B': // Down
+			if page < totalPages-1 {
+				page++
+			}
+		case n == 3 && buf[0] == 27 && buf[1] == '[' && buf[2] == 'A': // Up
+			if page > 0 {
+				page--
+			}
+		}
+	}
+
+	return nil
+}
+
+// ShouldPage returns true if output should be paginated
+// (stdout is a TTY and there are more lines than fit on screen).
+func ShouldPage(lineCount int) bool {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return false
+	}
+	return lineCount > detectPageSize()-3
+}
+
+func detectPageSize() int {
+	_, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || h < 10 {
+		return 24 // safe default
+	}
+	return h
+}
+
+func pagerFallback(cfg PagerConfig) error {
+	if cfg.Header != "" {
+		fmt.Println(cfg.Header)
+	}
+	for _, line := range cfg.Lines {
+		fmt.Println(line)
+	}
+	return nil
+}

--- a/internal/interactive/pager.go
+++ b/internal/interactive/pager.go
@@ -22,6 +22,7 @@ type PagerConfig struct {
 // Pager displays lines page by page in the terminal.
 // Navigation: Enter/Space = next page, b = previous page, q = quit.
 // If the output fits in one page, prints directly without pagination.
+//nolint:gocyclo // Interactive key handling is intentionally centralized.
 func Pager(cfg PagerConfig) error {
 	if len(cfg.Lines) == 0 {
 		return nil
@@ -62,7 +63,9 @@ func Pager(cfg PagerConfig) error {
 		// Fallback: print everything.
 		return pagerFallback(cfg)
 	}
-	defer term.Restore(fd, oldState)
+	defer func() {
+		_ = term.Restore(fd, oldState)
+	}()
 
 	page := 0
 

--- a/internal/interactive/prompter_test.go
+++ b/internal/interactive/prompter_test.go
@@ -286,6 +286,7 @@ func TestMockPrompter_Select_Branches(t *testing.T) {
 
 func TestSelectProject_WithMockPrompter(t *testing.T) {
 	ctx := context.Background()
+	// Index 1 = second project (auto-adjusted past Browse nav options)
 	mockPrompt := NewMockPrompter().WithSelectResponses(SelectResponse{Index: 1})
 	mockClient := &client.MockClient{
 		GetProjectsFunc: func(ctx context.Context) (data.GetProjectsResponse, error) {

--- a/internal/interactive/server.go
+++ b/internal/interactive/server.go
@@ -1,0 +1,28 @@
+package interactive
+
+import (
+	"context"
+	"fmt"
+)
+
+// SelectServer presents the configured server URL for confirmation.
+// If the URL is empty, it returns an error asking the user to configure first.
+// Returns the confirmed base URL or an error (including ErrGoBack/ErrExit).
+func SelectServer(ctx context.Context, p Prompter, baseURL string) (string, error) {
+	if baseURL == "" {
+		return "", fmt.Errorf("no server configured; run 'gotr config init' first")
+	}
+
+	ok, err := p.Confirm(fmt.Sprintf("⚡ You are connecting to: %s. Continue?", baseURL), true)
+	if err != nil {
+		if IsGoBack(err) || IsExit(err) || IsInterrupt(err) {
+			return "", err
+		}
+		return "", fmt.Errorf("server confirmation: %w", err)
+	}
+	if !ok {
+		return "", ErrExit
+	}
+
+	return baseURL, nil
+}

--- a/internal/interactive/server_test.go
+++ b/internal/interactive/server_test.go
@@ -1,0 +1,42 @@
+package interactive
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSelectServer_EmptyURL(t *testing.T) {
+	p := NewMockPrompter()
+	ctx := WithPrompter(context.Background(), p)
+
+	_, err := SelectServer(ctx, p, "")
+	if err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+	if err.Error() != "no server configured; run 'gotr config init' first" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSelectServer_Confirmed(t *testing.T) {
+	p := NewMockPrompter().WithConfirmResponses(true)
+	ctx := WithPrompter(context.Background(), p)
+
+	url, err := SelectServer(ctx, p, "https://example.testrail.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://example.testrail.io" {
+		t.Errorf("got %q, want %q", url, "https://example.testrail.io")
+	}
+}
+
+func TestSelectServer_Rejected(t *testing.T) {
+	p := NewMockPrompter().WithConfirmResponses(false)
+	ctx := WithPrompter(context.Background(), p)
+
+	_, err := SelectServer(ctx, p, "https://example.testrail.io")
+	if !IsExit(err) {
+		t.Errorf("expected ErrExit, got %v", err)
+	}
+}

--- a/internal/interactive/session.go
+++ b/internal/interactive/session.go
@@ -37,14 +37,14 @@ func (s *WorkSession) SetSuites(src, dst int64) {
 }
 
 // Projects returns the stored project IDs (src, dst).
-func (s *WorkSession) Projects() (int64, int64) {
+func (s *WorkSession) Projects() (src, dst int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.SrcProjectID, s.DstProjectID
 }
 
 // Suites returns the stored suite IDs (src, dst).
-func (s *WorkSession) Suites() (int64, int64) {
+func (s *WorkSession) Suites() (src, dst int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.SrcSuiteID, s.DstSuiteID

--- a/internal/interactive/session.go
+++ b/internal/interactive/session.go
@@ -1,0 +1,64 @@
+package interactive
+
+import (
+	"context"
+	"sync"
+)
+
+// WorkSession holds mutable state that is shared between commands
+// during an interactive gotr work session. It allows parameter inheritance:
+// compare → sync → snap without re-prompting for project IDs.
+//
+// WorkSession is concurrency-safe via an internal mutex.
+type WorkSession struct {
+	mu sync.Mutex
+
+	ServerURL       string
+	SrcProjectID    int64
+	DstProjectID    int64
+	SrcSuiteID      int64
+	DstSuiteID      int64
+}
+
+// SetProjects stores the source and destination project IDs.
+func (s *WorkSession) SetProjects(src, dst int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SrcProjectID = src
+	s.DstProjectID = dst
+}
+
+// SetSuites stores the source and destination suite IDs.
+func (s *WorkSession) SetSuites(src, dst int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SrcSuiteID = src
+	s.DstSuiteID = dst
+}
+
+// Projects returns the stored project IDs (src, dst).
+func (s *WorkSession) Projects() (int64, int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.SrcProjectID, s.DstProjectID
+}
+
+// Suites returns the stored suite IDs (src, dst).
+func (s *WorkSession) Suites() (int64, int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.SrcSuiteID, s.DstSuiteID
+}
+
+type sessionContextKey struct{}
+
+// WithSession returns a new context that carries the given WorkSession.
+func WithSession(ctx context.Context, s *WorkSession) context.Context {
+	return context.WithValue(ctx, sessionContextKey{}, s)
+}
+
+// SessionFromContext returns the WorkSession from context, or nil if absent.
+func SessionFromContext(ctx context.Context) *WorkSession {
+	s, _ := ctx.Value(sessionContextKey{}).(*WorkSession)
+	return s
+}

--- a/internal/interactive/session_test.go
+++ b/internal/interactive/session_test.go
@@ -33,6 +33,7 @@ func TestWithSession_RoundTrip(t *testing.T) {
 	got := SessionFromContext(ctx)
 	if got == nil {
 		t.Fatal("SessionFromContext returned nil")
+		return
 	}
 	if got.ServerURL != "https://example.testrail.io" {
 		t.Errorf("ServerURL = %q, want %q", got.ServerURL, "https://example.testrail.io")

--- a/internal/interactive/session_test.go
+++ b/internal/interactive/session_test.go
@@ -1,0 +1,51 @@
+package interactive
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWorkSession_SetAndGetProjects(t *testing.T) {
+	s := &WorkSession{}
+	s.SetProjects(10, 20)
+
+	src, dst := s.Projects()
+	if src != 10 || dst != 20 {
+		t.Errorf("Projects() = (%d, %d), want (10, 20)", src, dst)
+	}
+}
+
+func TestWorkSession_SetAndGetSuites(t *testing.T) {
+	s := &WorkSession{}
+	s.SetSuites(5, 15)
+
+	src, dst := s.Suites()
+	if src != 5 || dst != 15 {
+		t.Errorf("Suites() = (%d, %d), want (5, 15)", src, dst)
+	}
+}
+
+func TestWithSession_RoundTrip(t *testing.T) {
+	s := &WorkSession{ServerURL: "https://example.testrail.io"}
+	s.SetProjects(1, 2)
+
+	ctx := WithSession(context.Background(), s)
+	got := SessionFromContext(ctx)
+	if got == nil {
+		t.Fatal("SessionFromContext returned nil")
+	}
+	if got.ServerURL != "https://example.testrail.io" {
+		t.Errorf("ServerURL = %q, want %q", got.ServerURL, "https://example.testrail.io")
+	}
+	src, dst := got.Projects()
+	if src != 1 || dst != 2 {
+		t.Errorf("Projects() = (%d, %d), want (1, 2)", src, dst)
+	}
+}
+
+func TestSessionFromContext_Missing(t *testing.T) {
+	got := SessionFromContext(context.Background())
+	if got != nil {
+		t.Errorf("SessionFromContext on empty ctx = %v, want nil", got)
+	}
+}

--- a/internal/snap/attachments.go
+++ b/internal/snap/attachments.go
@@ -48,7 +48,6 @@ type PromptFunc func(att data.Attachment, maxMB int) bool
 // Respects SnapConfig: save_binary mode, max file size, gzip compression.
 // Use promptFn to interactively ask about large files (pass nil for non-interactive).
 // Returns the number of attachments saved.
-//nolint:gocyclo // Branching is intentional for snapshot policy handling.
 func SaveCaseAttachments(
 	ctx context.Context,
 	api AttachmentsAPI,

--- a/internal/snap/attachments.go
+++ b/internal/snap/attachments.go
@@ -48,6 +48,7 @@ type PromptFunc func(att data.Attachment, maxMB int) bool
 // Respects SnapConfig: save_binary mode, max file size, gzip compression.
 // Use promptFn to interactively ask about large files (pass nil for non-interactive).
 // Returns the number of attachments saved.
+//nolint:gocyclo // Branching is intentional for snapshot policy handling.
 func SaveCaseAttachments(
 	ctx context.Context,
 	api AttachmentsAPI,
@@ -163,19 +164,26 @@ func RestoreCaseAttachments(
 		srcPath := filepath.Join(dir, entry.File)
 
 		uploadPath := srcPath
+		tmpPath := ""
 		if entry.Compressed {
 			// Decompress to temp file for upload.
 			tmp, err := decompressToTemp(srcPath, entry.Name)
 			if err != nil {
 				return restored, fmt.Errorf("decompress attachment %d: %w", entry.ID, err)
 			}
-			defer os.Remove(tmp)
 			uploadPath = tmp
+			tmpPath = tmp
 		}
 
 		_, err := api.AddAttachmentToCase(ctx, caseID, uploadPath)
 		if err != nil {
+			if tmpPath != "" {
+				_ = os.Remove(tmpPath)
+			}
 			return restored, fmt.Errorf("upload attachment %d (%s): %w", entry.ID, entry.Name, err)
+		}
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
 		}
 		restored++
 	}
@@ -290,7 +298,7 @@ func loadAttachManifest(store *Store, snapID string) (*AttachmentManifest, error
 	dir := store.SnapDir(snapID)
 	path := filepath.Join(dir, attachManifestFile)
 
-	data, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -299,7 +307,7 @@ func loadAttachManifest(store *Store, snapID string) (*AttachmentManifest, error
 	}
 
 	var manifest AttachmentManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
+	if err := json.Unmarshal(raw, &manifest); err != nil {
 		return nil, fmt.Errorf("decode attachment manifest: %w", err)
 	}
 	return &manifest, nil

--- a/internal/snap/manifest.go
+++ b/internal/snap/manifest.go
@@ -15,18 +15,20 @@ const ManifestFile = "manifest.json"
 
 // ManifestEntry is a lightweight index entry for a snapshot.
 type ManifestEntry struct {
-	ID           string    `json:"id"`
-	Name         string    `json:"name,omitempty"`
-	Label        string    `json:"label,omitempty"`
-	ServerURL    string    `json:"server_url,omitempty"`
-	Category     Category  `json:"category"`
-	Operation    Operation `json:"operation"`
-	EntityType   string    `json:"entity_type"`
-	EntityIDs    []int64   `json:"entity_ids,omitempty"`
-	RollbackTier Tier      `json:"rollback_tier"`
-	Status       Status    `json:"status"`
-	Timestamp    time.Time `json:"timestamp"`
-	DataSize     int64     `json:"data_size_bytes"`
+	ID              string    `json:"id"`
+	Name            string    `json:"name,omitempty"`
+	Label           string    `json:"label,omitempty"`
+	ServerURL       string    `json:"server_url,omitempty"`
+	Category        Category  `json:"category"`
+	Operation       Operation `json:"operation"`
+	EntityType      string    `json:"entity_type"`
+	EntityIDs       []int64   `json:"entity_ids,omitempty"`
+	ProjectID       int64     `json:"project_id,omitempty"`
+	SourceProjectID int64     `json:"source_project_id,omitempty"`
+	RollbackTier    Tier      `json:"rollback_tier"`
+	Status          Status    `json:"status"`
+	Timestamp       time.Time `json:"timestamp"`
+	DataSize        int64     `json:"data_size_bytes"`
 }
 
 // Manifest is the top-level snapshot index stored in manifest.json.
@@ -63,18 +65,20 @@ func (m *Manifest) Add(meta *Meta) error {
 	defer m.mu.Unlock()
 
 	entry := ManifestEntry{
-		ID:           meta.ID,
-		Name:         meta.Name,
-		Label:        meta.Label,
-		ServerURL:    meta.ServerURL,
-		Category:     meta.Category,
-		Operation:    meta.Operation,
-		EntityType:   meta.EntityType,
-		EntityIDs:    meta.EntityIDs,
-		RollbackTier: meta.RollbackTier,
-		Status:       meta.Status,
-		Timestamp:    meta.Timestamp,
-		DataSize:     meta.DataSizeBytes,
+		ID:              meta.ID,
+		Name:            meta.Name,
+		Label:           meta.Label,
+		ServerURL:       meta.ServerURL,
+		Category:        meta.Category,
+		Operation:       meta.Operation,
+		EntityType:      meta.EntityType,
+		EntityIDs:       meta.EntityIDs,
+		ProjectID:       meta.ProjectID,
+		SourceProjectID: meta.SourceProjectID,
+		RollbackTier:    meta.RollbackTier,
+		Status:          meta.Status,
+		Timestamp:       meta.Timestamp,
+		DataSize:        meta.DataSizeBytes,
 	}
 
 	m.Entries = append(m.Entries, entry)

--- a/internal/snap/manifest.go
+++ b/internal/snap/manifest.go
@@ -114,6 +114,20 @@ func (m *Manifest) UpdateStatus(snapID string, status Status) error {
 	return fmt.Errorf("snap: entry %q not found in manifest", snapID)
 }
 
+// UpdateLabel changes the label of an entry and saves.
+func (m *Manifest) UpdateLabel(snapID, label string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i := range m.Entries {
+		if m.Entries[i].ID == snapID {
+			m.Entries[i].Label = label
+			return m.save()
+		}
+	}
+	return fmt.Errorf("snap: entry %q not found in manifest", snapID)
+}
+
 // Find returns the entry with the given ID or name, or nil.
 func (m *Manifest) Find(idOrName string) *ManifestEntry {
 	m.mu.Lock()

--- a/internal/snap/manifest_test.go
+++ b/internal/snap/manifest_test.go
@@ -186,3 +186,116 @@ func TestManifest_EmptyDir(t *testing.T) {
 	assert.Equal(t, 0, manifest.Len())
 	assert.Nil(t, manifest.Latest())
 }
+
+func TestManifest_Add_CopiesProjectIDs(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	manifest, err := LoadManifest(store)
+	require.NoError(t, err)
+
+	meta := &Meta{
+		ID:              "cases/proj_test",
+		Category:        Category("cases"),
+		Operation:       OpUpdate,
+		EntityType:      "case",
+		Status:          StatusAvailable,
+		ProjectID:       42,
+		SourceProjectID: 10,
+	}
+
+	require.NoError(t, manifest.Add(meta))
+
+	entry := manifest.Find("cases/proj_test")
+	require.NotNil(t, entry)
+	assert.Equal(t, int64(42), entry.ProjectID, "ProjectID should be copied from Meta")
+	assert.Equal(t, int64(10), entry.SourceProjectID, "SourceProjectID should be copied from Meta")
+}
+
+func TestManifest_LegacyEntry_ZeroProjectIDs(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	manifest, err := LoadManifest(store)
+	require.NoError(t, err)
+
+	// Legacy meta without project IDs.
+	meta := &Meta{
+		ID:         "suites/legacy_1",
+		Category:   Category("suites"),
+		Operation:  OpUpdate,
+		EntityType: "suite",
+		Status:     StatusAvailable,
+	}
+
+	require.NoError(t, manifest.Add(meta))
+
+	entry := manifest.Find("suites/legacy_1")
+	require.NotNil(t, entry)
+	assert.Equal(t, int64(0), entry.ProjectID, "legacy entry should have zero ProjectID")
+	assert.Equal(t, int64(0), entry.SourceProjectID, "legacy entry should have zero SourceProjectID")
+}
+
+func TestManifest_ProjectIDs_PersistRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	manifest, err := LoadManifest(store)
+	require.NoError(t, err)
+
+	meta := &Meta{
+		ID:              "cases/roundtrip_1",
+		Category:        Category("cases"),
+		Operation:       OpUpdate,
+		EntityType:      "case",
+		Status:          StatusAvailable,
+		ProjectID:       100,
+		SourceProjectID: 50,
+	}
+	require.NoError(t, manifest.Add(meta))
+
+	// Reload from disk.
+	manifest2, err := LoadManifest(store)
+	require.NoError(t, err)
+
+	entry := manifest2.Find("cases/roundtrip_1")
+	require.NotNil(t, entry)
+	assert.Equal(t, int64(100), entry.ProjectID, "ProjectID should survive round-trip")
+	assert.Equal(t, int64(50), entry.SourceProjectID, "SourceProjectID should survive round-trip")
+}
+
+func TestManifest_OmitEmpty_LegacyRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	manifest, err := LoadManifest(store)
+	require.NoError(t, err)
+
+	// Legacy meta without project IDs — they should not appear in JSON.
+	meta := &Meta{
+		ID:         "suites/omit_1",
+		Category:   Category("suites"),
+		Operation:  OpDelete,
+		EntityType: "suite",
+		Status:     StatusAvailable,
+	}
+	require.NoError(t, manifest.Add(meta))
+
+	// Read raw JSON to verify omitempty.
+	raw, err := os.ReadFile(store.BaseDir() + "/" + ManifestFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "project_id", "zero ProjectID should be omitted from JSON")
+	assert.NotContains(t, string(raw), "source_project_id", "zero SourceProjectID should be omitted from JSON")
+
+	// Reload and verify zero values.
+	manifest2, err := LoadManifest(store)
+	require.NoError(t, err)
+	entry := manifest2.Find("suites/omit_1")
+	require.NotNil(t, entry)
+	assert.Equal(t, int64(0), entry.ProjectID)
+	assert.Equal(t, int64(0), entry.SourceProjectID)
+}

--- a/internal/snap/rollback.go
+++ b/internal/snap/rollback.go
@@ -72,6 +72,7 @@ type RollbackAPI interface {
 }
 
 // CasesAPI is an alias for backward compatibility.
+//
 // Deprecated: use RollbackAPI.
 type CasesAPI = RollbackAPI
 
@@ -89,7 +90,7 @@ type RollbackResult struct {
 	Operation   Operation
 	EntityType  string
 	Success     bool
-	NewEntityID int64  // non-zero if a new entity was created (e.g. delete rollback)
+	NewEntityID int64 // non-zero if a new entity was created (e.g. delete rollback)
 	Message     string
 	DryRun      bool
 
@@ -107,6 +108,7 @@ type DiffEntry struct {
 
 // Rollback reverses a mutation using the saved snapshot data.
 // Accepts optional RollbackOpts for entity filtering and dry-run mode.
+//nolint:gocyclo // Rollback dispatcher is intentionally exhaustive by entity type.
 func Rollback(ctx context.Context, api CasesAPI, store *Store, manifest *Manifest, snapID string, opts ...RollbackOpts) (*RollbackResult, error) {
 	var opt RollbackOpts
 	if len(opts) > 0 {
@@ -398,12 +400,12 @@ func buildCaseDiff(caseID int64, current, saved *data.Case) []DiffEntry {
 
 // buildCaseAddPreview shows fields that would be restored for a deleted case.
 func buildCaseAddPreview(caseID int64, saved *data.Case) []DiffEntry {
-	var diffs []DiffEntry
-	diffs = append(diffs, DiffEntry{EntityID: caseID, Field: "action", Current: "DELETED", Saved: "RE-CREATE"})
-	diffs = append(diffs, DiffEntry{EntityID: caseID, Field: "title", Current: "—", Saved: saved.Title})
-	diffs = append(diffs, DiffEntry{EntityID: caseID, Field: "section_id", Current: "—", Saved: fmt.Sprintf("%d", saved.SectionID)})
-	diffs = append(diffs, DiffEntry{EntityID: caseID, Field: "priority_id", Current: "—", Saved: fmt.Sprintf("%d", saved.PriorityID)})
-	return diffs
+	return []DiffEntry{
+		{EntityID: caseID, Field: "action", Current: "DELETED", Saved: "RE-CREATE"},
+		{EntityID: caseID, Field: "title", Current: "—", Saved: saved.Title},
+		{EntityID: caseID, Field: "section_id", Current: "—", Saved: fmt.Sprintf("%d", saved.SectionID)},
+		{EntityID: caseID, Field: "priority_id", Current: "—", Saved: fmt.Sprintf("%d", saved.PriorityID)},
+	}
 }
 
 // caseToUpdateRequest converts a saved Case to an UpdateCaseRequest.
@@ -665,7 +667,7 @@ func rollbackSimpleEntity(ctx context.Context, api RollbackAPI, _ *Store, meta *
 
 	deleteFn, err := resolveDeleteFn(api, meta.EntityType)
 	if err != nil {
-		return err
+		return fmt.Errorf("rollbackSimpleEntity: %w", err)
 	}
 
 	if err := deleteFn(ctx, entityID); err != nil {
@@ -730,6 +732,7 @@ type CascadeData struct {
 }
 
 // rollbackSectionCascade re-creates a deleted section and its child cases.
+//nolint:gocyclo // Section cascade rollback contains explicit error handling per phase.
 func rollbackSectionCascade(ctx context.Context, api RollbackAPI, store *Store, meta *Meta, result *RollbackResult, opt RollbackOpts) error {
 
 	var cascade CascadeData

--- a/internal/snap/rollback.go
+++ b/internal/snap/rollback.go
@@ -113,7 +113,6 @@ type DiffEntry struct {
 
 // Rollback reverses a mutation using the saved snapshot data.
 // Accepts optional RollbackOpts for entity filtering and dry-run mode.
-//nolint:gocyclo // Rollback dispatcher is intentionally exhaustive by entity type.
 func Rollback(ctx context.Context, api CasesAPI, store *Store, manifest *Manifest, snapID string, opts ...RollbackOpts) (*RollbackResult, error) {
 	var opt RollbackOpts
 	if len(opts) > 0 {
@@ -731,7 +730,6 @@ type CascadeData struct {
 }
 
 // rollbackSectionCascade re-creates a deleted section and its child cases.
-//nolint:gocyclo // Section cascade rollback contains explicit error handling per phase.
 func rollbackSectionCascade(ctx context.Context, api RollbackAPI, store *Store, meta *Meta, result *RollbackResult, opt RollbackOpts) error {
 
 	var cascade CascadeData

--- a/internal/snap/store.go
+++ b/internal/snap/store.go
@@ -96,7 +96,7 @@ func (s *Store) SaveMeta(meta *Meta) error {
 }
 
 // SaveData writes entity data to a named JSON file in the snapshot directory using atomic write.
-func (s *Store) SaveData(snapID string, filename string, data interface{}) (int64, error) {
+func (s *Store) SaveData(snapID, filename string, data interface{}) (int64, error) {
 	dir := s.snapDir(snapID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return 0, fmt.Errorf("snap: create dir %s: %w", snapID, err)
@@ -121,7 +121,7 @@ func (s *Store) LoadMeta(snapID string) (*Meta, error) {
 }
 
 // LoadData reads a named JSON file from a snapshot directory into dst.
-func (s *Store) LoadData(snapID string, filename string, dst interface{}) error {
+func (s *Store) LoadData(snapID, filename string, dst interface{}) error {
 	p := filepath.Join(s.snapDir(snapID), filename)
 	f, err := os.Open(p)
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *Store) SnapDir(snapID string) string {
 
 // Export copies meta.json and data files from a snapshot into a single JSON file.
 // The exported file contains {"meta": {...}, "data": {...}} for portability.
-func (s *Store) Export(snapID string, outPath string) error {
+func (s *Store) Export(snapID, outPath string) error {
 	meta, err := s.LoadMeta(snapID)
 	if err != nil {
 		return fmt.Errorf("snap export: %w", err)
@@ -272,7 +272,7 @@ func atomicWriteJSON(path string, data interface{}) error {
 }
 
 // readJSON is a generic helper to read and decode a JSON file.
-func readJSON[T any](path string, snapID string) (*T, error) {
+func readJSON[T any](path, snapID string) (*T, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("snap: open meta %s: %w", snapID, err)


### PR DESCRIPTION
## Summary

Unified navigation hub, session context, AlignedLabels rollout (Tier 1-3), mutation post-actions and cross-nav dispatcher.

## Changes
- `cmd/work.go`, `cmd/work_hub.go`: unified work hub entry point
- `internal/interactive/session.go`: server session context
- `internal/interactive/nav_dispatch.go`, `server.go`: SelectServer + NavigateMenu extraction
- `internal/interactive/mutation_action.go`: standardized post-mutation menu
- `internal/interactive/cross_nav.go`: cross-command navigation dispatcher
- AlignedLabels Tier 1-3 across all interactive pickers

## Closes
Closes #30

## Depends on
- #28 (feat/28-snap-backup-core must be merged first)

## Acceptance Criteria
- [x] `go build ./...` passes
- [x] `go test ./...` passes (45 packages)
- [ ] Merged into `release-3.1.0`
