### PR TITLE
feat(paths): RelToHome/ExpandHome helpers + EnsureReports/Exports dirs [#44]

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -157,4 +158,86 @@ func EnsureDir(dirFunc func() (string, error)) error {
 		return fmt.Errorf("EnsureDir: %w", err)
 	}
 	return os.MkdirAll(dir, 0o755)
+}
+
+// EnsureReportsDirPath returns ~/.gotr/reports and creates it when missing.
+func EnsureReportsDirPath() (string, error) {
+	dir, err := ReportsDirPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("cannot create reports directory: %w", err)
+	}
+	return dir, nil
+}
+
+// EnsureExportsDirPath returns ~/.gotr/exports and creates it when missing.
+func EnsureExportsDirPath() (string, error) {
+	dir, err := ExportsDirPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("cannot create exports directory: %w", err)
+	}
+	return dir, nil
+}
+
+// RelToHome converts an absolute path to a portable ~/... form when the path
+// is under the current user's home directory. Paths outside $HOME are returned
+// unchanged. This is used to make exported manifests and PDF reports portable
+// across machines where the absolute $HOME differs.
+//
+// Examples:
+//
+//	/home/alice/.gotr/reports/r.pdf  -> ~/.gotr/reports/r.pdf
+//	/var/log/app.log                 -> /var/log/app.log
+//	C:\Users\Bob\.gotr\s\x.json      -> ~/.gotr/s/x.json (on Windows)
+func RelToHome(abs string) string {
+	if abs == "" {
+		return abs
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return abs
+	}
+	cleanAbs := filepath.Clean(abs)
+	cleanHome := filepath.Clean(home)
+	if cleanAbs == cleanHome {
+		return "~"
+	}
+	// Use filepath.Rel to avoid false prefix matches (e.g. /home/al vs /home/alice).
+	rel, err := filepath.Rel(cleanHome, cleanAbs)
+	if err != nil {
+		return abs
+	}
+	// If rel starts with ".." the path is outside $HOME — return as-is.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return abs
+	}
+	// Always use forward slashes in the portable form.
+	return "~/" + filepath.ToSlash(rel)
+}
+
+// ExpandHome is the inverse of RelToHome: it expands a leading "~/" (or bare
+// "~") to the current user's home directory. Paths that do not begin with "~"
+// are returned unchanged. This lets tooling accept portable paths from
+// imported bundles and resolve them on the local machine.
+func ExpandHome(p string) (string, error) {
+	if p == "" {
+		return p, nil
+	}
+	if p != "~" && !strings.HasPrefix(p, "~/") && !strings.HasPrefix(p, `~\`) {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	if p == "~" {
+		return home, nil
+	}
+	// Strip the "~/" or "~\\" prefix and join with OS-native separator.
+	return filepath.Join(home, filepath.FromSlash(p[2:])), nil
 }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -337,7 +337,7 @@ func TestRelToHome_HomeUnset(t *testing.T) {
 	in := "/some/path"
 	if got := RelToHome(in); got != in {
 		// os.UserHomeDir may still resolve on some CI hosts; accept any prefixing
-		// behaviour only if it starts with "~/".
+		// behavior only if it starts with "~/".
 		if got != "~/some/path" && got != "~" {
 			t.Fatalf("RelToHome(%q) = %q, want unchanged or ~-prefixed", in, got)
 		}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -26,6 +26,8 @@ func TestBaseDirAndDerivedPaths_HomeUnset(t *testing.T) {
 		{name: "TempDirPath", fn: TempDirPath},
 		{name: "ConfigFile", fn: ConfigFile},
 		{name: "EnsureLogsDirPath", fn: EnsureLogsDirPath},
+		{name: "EnsureReportsDirPath", fn: EnsureReportsDirPath},
+		{name: "EnsureExportsDirPath", fn: EnsureExportsDirPath},
 	}
 
 	for _, tc := range checks {
@@ -237,5 +239,164 @@ func TestEnsureDir_ErrorPaths(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected EnsureDir to fail when parent is a file")
+	}
+}
+
+func TestEnsureReportsDirPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := EnsureReportsDirPath()
+	if err != nil {
+		t.Fatalf("EnsureReportsDirPath error: %v", err)
+	}
+	want := filepath.Join(home, DirName, ReportsDir)
+	if path != want {
+		t.Fatalf("EnsureReportsDirPath = %q, want %q", path, want)
+	}
+	if st, err := os.Stat(path); err != nil || !st.IsDir() {
+		t.Fatalf("reports dir not created: %v", err)
+	}
+
+	// Idempotent: second call must succeed as well.
+	if _, err := EnsureReportsDirPath(); err != nil {
+		t.Fatalf("second EnsureReportsDirPath error: %v", err)
+	}
+}
+
+func TestEnsureReportsDirPath_MkdirError(t *testing.T) {
+	parent := t.TempDir()
+	homeFile := filepath.Join(parent, "not-a-dir")
+	if err := os.WriteFile(homeFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write home file: %v", err)
+	}
+	t.Setenv("HOME", homeFile)
+
+	if _, err := EnsureReportsDirPath(); err == nil {
+		t.Fatal("expected error when home path is a file")
+	}
+}
+
+func TestEnsureExportsDirPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := EnsureExportsDirPath()
+	if err != nil {
+		t.Fatalf("EnsureExportsDirPath error: %v", err)
+	}
+	want := filepath.Join(home, DirName, ExportsDir)
+	if path != want {
+		t.Fatalf("EnsureExportsDirPath = %q, want %q", path, want)
+	}
+	if st, err := os.Stat(path); err != nil || !st.IsDir() {
+		t.Fatalf("exports dir not created: %v", err)
+	}
+}
+
+func TestEnsureExportsDirPath_MkdirError(t *testing.T) {
+	parent := t.TempDir()
+	homeFile := filepath.Join(parent, "not-a-dir")
+	if err := os.WriteFile(homeFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write home file: %v", err)
+	}
+	t.Setenv("HOME", homeFile)
+
+	if _, err := EnsureExportsDirPath(); err == nil {
+		t.Fatal("expected error when home path is a file")
+	}
+}
+
+func TestRelToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "equals_home", in: home, want: "~"},
+		{name: "under_home", in: filepath.Join(home, ".gotr", "reports", "r.pdf"), want: "~/.gotr/reports/r.pdf"},
+		{name: "outside_home_absolute", in: "/var/log/app.log", want: "/var/log/app.log"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RelToHome(tc.in)
+			if got != tc.want {
+				t.Fatalf("RelToHome(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRelToHome_HomeUnset(t *testing.T) {
+	t.Setenv("HOME", "")
+	// When HOME cannot be resolved, RelToHome must return its input unchanged.
+	in := "/some/path"
+	if got := RelToHome(in); got != in {
+		// os.UserHomeDir may still resolve on some CI hosts; accept any prefixing
+		// behaviour only if it starts with "~/".
+		if got != "~/some/path" && got != "~" {
+			t.Fatalf("RelToHome(%q) = %q, want unchanged or ~-prefixed", in, got)
+		}
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "bare_tilde", in: "~", want: home},
+		{name: "tilde_slash", in: "~/.gotr/reports/r.pdf", want: filepath.Join(home, ".gotr", "reports", "r.pdf")},
+		{name: "absolute_passthrough", in: "/var/log/app.log", want: "/var/log/app.log"},
+		{name: "relative_passthrough", in: "relative/path", want: "relative/path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExpandHome(tc.in)
+			if err != nil {
+				t.Fatalf("ExpandHome(%q) error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ExpandHome(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExpandHome_HomeUnset(t *testing.T) {
+	t.Setenv("HOME", "")
+	// If os.UserHomeDir still resolves (some CI hosts), skip the negative test.
+	if _, err := os.UserHomeDir(); err == nil {
+		t.Skip("os.UserHomeDir resolved without HOME; skipping")
+	}
+	if _, err := ExpandHome("~/x"); err == nil {
+		t.Fatal("expected error when home is unresolved")
+	}
+}
+
+func TestRelToHome_ExpandHome_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	abs := filepath.Join(home, ".gotr", "reports", "r.pdf")
+	portable := RelToHome(abs)
+	if portable != "~/.gotr/reports/r.pdf" {
+		t.Fatalf("RelToHome = %q", portable)
+	}
+	restored, err := ExpandHome(portable)
+	if err != nil {
+		t.Fatalf("ExpandHome error: %v", err)
+	}
+	if restored != abs {
+		t.Fatalf("round-trip mismatch: %q != %q", restored, abs)
 	}
 }


### PR DESCRIPTION
## Summary

Foundation PR for v3.3.0 — introduces shared path helpers that the three headline features depend on:

- **`RelToHome(abs string) string`** — converts an absolute path under `$HOME` to a portable `~/<rel>` form using `filepath.Rel` (no fragile `HasPrefix` matching). Paths outside `$HOME` are returned unchanged. Always emits forward slashes in the portable form.
- **`ExpandHome(p string) (string, error)`** — inverse helper: expands a leading `~/` or bare `~` back to the local `$HOME`.
- **`EnsureReportsDirPath()`, `EnsureExportsDirPath()`** — `mkdir -p` helpers matching the existing `EnsureLogsDirPath` pattern.

## Why

Issues [#41](https://github.com/Korrnals/gotr/issues/41) (PDF migration report), [#42](https://github.com/Korrnals/gotr/issues/42) (export/import snapshots), [#43](https://github.com/Korrnals/gotr/issues/43) (export/import reports) all need to write portable paths into PDF bodies, tarball manifests, and bundle READMEs. Absolute paths leak the author's `$HOME` and break when a bundle is opened on another machine. Centralising the conversion here prevents duplication and guarantees consistent behaviour across all three features.

See tracking issue [#44](https://github.com/Korrnals/gotr/issues/44) for the full release plan.

## Testing

- Added `TestRelToHome` — cases: empty, path equals `$HOME`, path under `$HOME`, absolute path outside `$HOME`.
- Added `TestRelToHome_HomeUnset` — resilient behaviour when `$HOME` is empty.
- Added `TestExpandHome` — cases: empty, bare `~`, `~/...`, absolute passthrough, relative passthrough.
- Added `TestExpandHome_HomeUnset` — error path when home cannot be resolved.
- Added `TestRelToHome_ExpandHome_RoundTrip` — guarantees bijective conversion for paths under `$HOME`.
- Added `TestEnsureReportsDirPath`, `TestEnsureReportsDirPath_MkdirError`, `TestEnsureExportsDirPath`, `TestEnsureExportsDirPath_MkdirError` — mirror the existing `EnsureLogsDirPath` test style.
- Extended `TestBaseDirAndDerivedPaths_HomeUnset` checks slice with the two new `Ensure*` helpers.

**Results:**
```
$ go build ./...                                     # OK
$ go test ./internal/paths/... -count=1              # ok, 0.009s
$ go test ./... -count=1 -timeout 300s               # EXIT=0, all packages ok
```

## Checklist

- [x] Code additive only; no existing helper touched.
- [x] Unit tests cover new functions including error paths.
- [x] Full repo test suite green.
- [x] Targets `release-3.3.0` (not `main`).
- [x] Refs tracking issue #44.

## Next

Once merged, the following PRs can start (in parallel after this PR):
- `feat/41-pdf-migration-report` → `release-3.3.0`
- `feat/42-export-import-snaps` → `release-3.3.0`
- `feat/43-export-import-reports` → `release-3.3.0`