### PR TITLE
feat(#42,#43): portable export/import for snapshots and migration reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@
 
 ## [Unreleased]
 
+### Added — export/import bundles (#42, #43)
+
+- **`gotr export snap <id>` → portable tar.gz** with `manifest.json`
+  (`schema_version=1`, gotr version, created_at, per-file SHA-256 and
+  `~/.gotr/...` relative paths), `SHA256SUMS`, `README.txt` and the full
+  `~/.gotr/snaps/<id>/` subtree. Default destination
+  `~/.gotr/exports/snap_<id>_<label>_<YYYYMMDD>.tar.gz`. Flags:
+  `--out`, `--redact` (strips `assignee`, `assignee_email`, `assignee_name`,
+  `email` from JSON payloads and audits stripped paths via
+  `manifest.redacted_fields`).
+- **`gotr import snap <path.tar.gz>`** verifies SHA256SUMS and
+  `schema_version` before touching the store, then extracts into
+  `~/.gotr/snaps/<id>/`. Flags: `--overwrite` (backs up existing snap to
+  `~/.gotr/snaps/.trash/<id>_<ts>/`), `--rename-id <new>` (imports under a
+  new id and rewrites `meta.json.id` accordingly), `--dry-run`.
+- **`gotr export report <filename|all>` + `gotr import report <path>`.**
+  Single file → plain copy into `~/.gotr/exports/<basename>`; `all` →
+  zip bundle at `~/.gotr/exports/reports_<YYYYMMDD>.zip` with the same
+  manifest/SHA256SUMS/README layout. Import handles both plain files and
+  zip bundles. Flags: `--out`, `--filter <glob>`, `--overwrite`, `--dry-run`.
+- **`gotr report show <filename|latest>`** opens PDFs via the OS default
+  viewer (`xdg-open`/`open`/`rundll32`) and cats MD/JSON/TXT to stdout.
+- **`gotr report list --filter <glob>`** applies a glob to report
+  filenames and now also accepts `.pdf`/`.json` reports (previously only
+  `migration-*.md` was visible).
+- New internal packages: `internal/bundle` (tar.gz + zip + SHA-256 + manifest
+  primitives with zip-slip protection and deterministic archive output),
+  `internal/snapbundle`, `internal/reportbundle`.
+
 ### Fixed — migration engine (3.2.0 follow-up)
 
 - **Coverage-gate no longer false-negatives on name-resolved sections.**

--- a/cmd/bundlecmd/bundlecmd.go
+++ b/cmd/bundlecmd/bundlecmd.go
@@ -1,0 +1,46 @@
+// Package bundlecmd implements the top-level `gotr import` command and the
+// `gotr export snap|report` / `gotr import snap|report` subcommands that
+// package and restore portable snapshot and report bundles.
+package bundlecmd
+
+import (
+	"os"
+
+	"github.com/Korrnals/gotr/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// Register attaches export and import subcommands onto the given roots.
+//
+//	exportParent → `gotr export` (already exists; we add snap/report as children)
+//	root         → `gotr` (we add a new top-level `import` command)
+//
+// Version is the running gotr version (written into bundle manifests).
+func Register(root, exportParent *cobra.Command, version string) {
+	exportParent.AddCommand(newExportSnapCmd(version))
+	exportParent.AddCommand(newExportReportCmd(version))
+
+	importCmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import portable snapshot or report bundles",
+		Long:  "Import gotr bundles produced by `gotr export snap` or `gotr export report`.",
+	}
+	importCmd.AddCommand(newImportSnapCmd())
+	importCmd.AddCommand(newImportReportCmd())
+	root.AddCommand(importCmd)
+}
+
+// warnf is a shared helper that writes a warning to stderr.
+func warnf(format string, args ...any) {
+	ui.Warningf(os.Stderr, format, args...)
+}
+
+// successf writes a success message to stdout.
+func successf(format string, args ...any) {
+	ui.Successf(os.Stdout, format, args...)
+}
+
+// infof writes an info message to stdout.
+func infof(format string, args ...any) {
+	ui.Infof(os.Stdout, format, args...)
+}

--- a/cmd/bundlecmd/report.go
+++ b/cmd/bundlecmd/report.go
@@ -1,0 +1,90 @@
+package bundlecmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Korrnals/gotr/internal/paths"
+	"github.com/Korrnals/gotr/internal/reportbundle"
+	"github.com/spf13/cobra"
+)
+
+func newExportReportCmd(version string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report <filename|all>",
+		Short: "Export migration reports",
+		Long: `Export gotr migration reports from ~/.gotr/reports/.
+  report <filename>   Copies a single file to ~/.gotr/exports/<basename>.
+  report all          Bundles all reports into
+                      ~/.gotr/exports/reports_<YYYYMMDD>.zip.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reportsDir, err := paths.ReportsDirPath()
+			if err != nil {
+				return fmt.Errorf("export report: %w", err)
+			}
+			outPath, _ := cmd.Flags().GetString("out")
+			filter, _ := cmd.Flags().GetString("filter")
+
+			target := args[0]
+			var res *reportbundle.Result
+			switch target {
+			case "all":
+				res, err = reportbundle.ExportAll(reportsDir, outPath, reportbundle.ExportOptions{
+					GotrVersion: version,
+					Filter:      filter,
+				})
+			default:
+				if filter != "" {
+					return fmt.Errorf("export report: --filter is only valid with 'all'")
+				}
+				res, err = reportbundle.ExportSingle(reportsDir, target, outPath)
+			}
+			if err != nil {
+				return err
+			}
+			if target == "all" {
+				successf("Exported %d reports → %s", len(res.Files), res.ArchivePath)
+			} else {
+				successf("Exported report %s → %s", target, res.ArchivePath)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("out", "", "Destination path (default: ~/.gotr/exports/<name>)")
+	cmd.Flags().String("filter", "", "When exporting 'all', keep only reports whose name matches this glob")
+	return cmd
+}
+
+func newImportReportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report <path.zip|path.pdf|path.md|path.json>",
+		Short: "Import reports into ~/.gotr/reports/",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reportsDir, err := paths.ReportsDirPath()
+			if err != nil {
+				return fmt.Errorf("import report: %w", err)
+			}
+			overwrite, _ := cmd.Flags().GetBool("overwrite")
+			dry, _ := cmd.Flags().GetBool("dry-run")
+
+			res, err := reportbundle.Import(reportsDir, args[0], reportbundle.ImportOptions{
+				Overwrite: overwrite,
+				DryRun:    dry,
+			})
+			if err != nil {
+				return err
+			}
+			verb := "Imported"
+			if dry {
+				verb = "Would import"
+			}
+			successf("%s %d report(s): %s", verb, len(res.Copied), strings.Join(res.Copied, ", "))
+			return nil
+		},
+	}
+	cmd.Flags().Bool("overwrite", false, "Overwrite existing reports with the same filename")
+	cmd.Flags().Bool("dry-run", false, "Validate and show what would be imported; no changes")
+	return cmd
+}

--- a/cmd/bundlecmd/snap.go
+++ b/cmd/bundlecmd/snap.go
@@ -1,0 +1,118 @@
+package bundlecmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Korrnals/gotr/internal/snap"
+	"github.com/Korrnals/gotr/internal/snapbundle"
+	"github.com/spf13/cobra"
+)
+
+func newExportSnapCmd(version string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snap <snap_id|label>",
+		Short: "Export a snapshot as a portable tar.gz bundle",
+		Long: `Export a single snapshot to a tar.gz archive under ~/.gotr/exports/.
+The archive contains manifest.json (with schema_version, gotr version,
+file list with SHA-256), SHA256SUMS, README.txt and the full
+~/.gotr/snaps/<id>/ tree.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := snap.NewStore()
+			if err != nil {
+				return fmt.Errorf("export snap: %w", err)
+			}
+			manifest, err := snap.LoadManifest(store)
+			if err != nil {
+				return fmt.Errorf("export snap: %w", err)
+			}
+			entry := manifest.Find(args[0])
+			if entry == nil {
+				return fmt.Errorf("export snap: snapshot %q not found", args[0])
+			}
+			outPath, _ := cmd.Flags().GetString("out")
+			if outPath == "" {
+				p, err := snapbundle.DefaultExportPath(entry.ID, entry.Label)
+				if err != nil {
+					return fmt.Errorf("export snap: %w", err)
+				}
+				outPath = p
+			}
+			redact, _ := cmd.Flags().GetBool("redact")
+
+			res, err := snapbundle.ExportOne(store, entry.ID, outPath, snapbundle.ExportOptions{
+				GotrVersion: version,
+				Redact:      redact,
+			})
+			if err != nil {
+				return err
+			}
+			successf("Exported snapshot %s → %s", res.SnapID, res.ArchivePath)
+			if len(res.Redacted) > 0 {
+				warnf("redacted fields: %s", strings.Join(res.Redacted, ", "))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("out", "", "Destination path (default: ~/.gotr/exports/snap_<id>_<date>.tar.gz)")
+	cmd.Flags().Bool("redact", false, "Strip assignee emails, names, and other sensitive fields from meta.json")
+	return cmd
+}
+
+func newImportSnapCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snap <path.tar.gz>",
+		Short: "Import a snapshot bundle into ~/.gotr/snaps/",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := snap.NewStore()
+			if err != nil {
+				return fmt.Errorf("import snap: %w", err)
+			}
+			overwrite, _ := cmd.Flags().GetBool("overwrite")
+			rename, _ := cmd.Flags().GetString("rename-id")
+			dry, _ := cmd.Flags().GetBool("dry-run")
+
+			res, err := snapbundle.Import(store, args[0], snapbundle.ImportOptions{
+				Overwrite: overwrite,
+				RenameID:  rename,
+				DryRun:    dry,
+			})
+			if err != nil {
+				return err
+			}
+			if dry {
+				infof("Would import snapshot %s (%d files) from %s", res.SnapID, len(res.Files), res.ArchivePath)
+				return nil
+			}
+			successf("Imported snapshot %s (%d files) from %s", res.SnapID, len(res.Files), res.ArchivePath)
+			// Keep manifest in sync if target was a fresh id.
+			if err := reindexImported(store, res.SnapID); err != nil {
+				warnf("manifest refresh: %v", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().Bool("overwrite", false, "Replace an existing snapshot; the old one is moved to ~/.gotr/snaps/.trash/")
+	cmd.Flags().String("rename-id", "", "Import under this snapshot id instead of the one recorded in the bundle")
+	cmd.Flags().Bool("dry-run", false, "Validate the bundle and print what would be imported; no changes")
+	return cmd
+}
+
+// reindexImported adds a manifest entry for a freshly imported snapshot
+// when one is missing. It is best-effort: failures are logged and ignored.
+func reindexImported(store *snap.Store, snapID string) error {
+	meta, err := store.LoadMeta(snapID)
+	if err != nil {
+		return err
+	}
+	manifest, err := snap.LoadManifest(store)
+	if err != nil {
+		return err
+	}
+	if manifest.Find(snapID) != nil {
+		return nil
+	}
+	return manifest.Add(meta)
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Korrnals/gotr/cmd/attachments"
 	"github.com/Korrnals/gotr/cmd/bdds"
+	bundlecmd "github.com/Korrnals/gotr/cmd/bundlecmd"
 	"github.com/Korrnals/gotr/cmd/cases"
 	"github.com/Korrnals/gotr/cmd/compare"
 	"github.com/Korrnals/gotr/cmd/configurations"
@@ -73,6 +74,10 @@ func init() {
 	tests.Register(rootCmd, GetClient)
 	users.Register(rootCmd, GetClient)
 	variables.Register(rootCmd, GetClient)
+
+	// Snapshot / report bundle export+import (hangs `snap`, `report` subcommands
+	// under `gotr export` and registers a new top-level `gotr import`).
+	bundlecmd.Register(rootCmd, exportCmd, Version)
 }
 
 // must terminates the process if err is non-nil. Used for init-time bindings

--- a/cmd/report/list.go
+++ b/cmd/report/list.go
@@ -3,6 +3,7 @@ package report
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -29,14 +30,26 @@ func newListCmd() *cobra.Command {
 				return fmt.Errorf("report list: read reports dir: %w", err)
 			}
 
+			filter, _ := cmd.Flags().GetString("filter")
 			reports := make([]string, 0)
 			for _, e := range entries {
 				if e.IsDir() {
 					continue
 				}
-				if strings.HasPrefix(e.Name(), "migration-") && strings.HasSuffix(e.Name(), ".md") {
-					reports = append(reports, e.Name())
+				name := e.Name()
+				if !reportLike(name) {
+					continue
 				}
+				if filter != "" {
+					match, err := filepath.Match(filter, name)
+					if err != nil {
+						return fmt.Errorf("report list: bad filter %q: %w", filter, err)
+					}
+					if !match {
+						continue
+					}
+				}
+				reports = append(reports, name)
 			}
 			if len(reports) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "No reports found")
@@ -58,5 +71,20 @@ func newListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Int("limit", 20, "Max number of reports to show")
+	cmd.Flags().String("filter", "", "Glob applied to report filenames (e.g. 'migration-*')")
 	return cmd
+}
+
+// reportLike returns true when the filename looks like a migration report
+// that gotr manages (by convention: migration-*.{md,pdf,json} or any file
+// ending in one of those extensions).
+func reportLike(name string) bool {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasPrefix(lower, "migration-"):
+		return strings.HasSuffix(lower, ".md") || strings.HasSuffix(lower, ".pdf") || strings.HasSuffix(lower, ".json")
+	case strings.HasSuffix(lower, ".md"), strings.HasSuffix(lower, ".pdf"), strings.HasSuffix(lower, ".json"):
+		return true
+	}
+	return false
 }

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -14,5 +14,6 @@ func Register(root *cobra.Command) {
 
 	reportCmd.AddCommand(newListCmd())
 	reportCmd.AddCommand(newViewCmd())
+	reportCmd.AddCommand(newShowCmd())
 	root.AddCommand(reportCmd)
 }

--- a/cmd/report/show.go
+++ b/cmd/report/show.go
@@ -1,0 +1,95 @@
+package report
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Korrnals/gotr/internal/paths"
+	"github.com/spf13/cobra"
+)
+
+func newShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <filename|latest>",
+		Short: "Open a migration report in the OS default viewer (PDF) or print it (md/json)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reportsDir, err := paths.ReportsDirPath()
+			if err != nil {
+				return fmt.Errorf("report show: resolve reports dir: %w", err)
+			}
+			target := args[0]
+			if target == "latest" {
+				latest, err := resolveLatestReport(reportsDir)
+				if err != nil {
+					return fmt.Errorf("report show: %w", err)
+				}
+				target = latest
+			}
+			path := filepath.Join(reportsDir, target)
+			if _, err := os.Stat(path); err != nil {
+				return fmt.Errorf("report show: %w", err)
+			}
+
+			ext := strings.ToLower(filepath.Ext(target))
+			switch ext {
+			case ".pdf":
+				if err := openWithOS(path); err != nil {
+					return fmt.Errorf("report show: open PDF: %w", err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Opened %s\n", path)
+				return nil
+			case ".md", ".json", ".txt", "":
+				return catFile(cmd.OutOrStdout(), path)
+			default:
+				// Best-effort: fall back to OS opener for unknown extensions.
+				if err := openWithOS(path); err != nil {
+					return fmt.Errorf("report show: open %s: %w", ext, err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Opened %s\n", path)
+				return nil
+			}
+		},
+	}
+}
+
+func catFile(w io.Writer, path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // path is inside reports dir resolved from paths helper
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// openWithOS invokes the OS default file opener: xdg-open on Linux, open on
+// macOS, rundll32 on Windows. Returns an error if no opener is available.
+func openWithOS(path string) error {
+	var (
+		bin  string
+		args []string
+	)
+	switch runtime.GOOS {
+	case "linux":
+		bin = "xdg-open"
+		args = []string{path}
+	case "darwin":
+		bin = "open"
+		args = []string{path}
+	case "windows":
+		bin = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", path}
+	default:
+		return errors.New("unsupported platform for `report show` — cat the file manually")
+	}
+	if _, err := exec.LookPath(bin); err != nil {
+		return fmt.Errorf("opener %q not found in PATH", bin)
+	}
+	return exec.Command(bin, args...).Start() //nolint:gosec // bin is a fixed per-OS constant
+}

--- a/cmd/report/view.go
+++ b/cmd/report/view.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/Korrnals/gotr/internal/paths"
 	"github.com/spf13/cobra"
@@ -58,7 +57,7 @@ func resolveLatestReport(reportsDir string) (string, error) {
 		if e.IsDir() {
 			continue
 		}
-		if strings.HasPrefix(e.Name(), "migration-") && strings.HasSuffix(e.Name(), ".md") {
+		if reportLike(e.Name()) {
 			reports = append(reports, e.Name())
 		}
 	}

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -1,0 +1,138 @@
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSHA256Bytes_Deterministic(t *testing.T) {
+	h1 := SHA256Bytes([]byte("hello world"))
+	h2 := SHA256Bytes([]byte("hello world"))
+	if h1 != h2 {
+		t.Fatalf("expected identical hashes, got %s vs %s", h1, h2)
+	}
+	if len(h1) != 64 {
+		t.Fatalf("expected 64-char hex hash, got len=%d", len(h1))
+	}
+}
+
+func TestFormatAndParseSHA256Sums_Roundtrip(t *testing.T) {
+	files := []File{
+		{Path: "b.txt", SHA256: strings.Repeat("b", 64)},
+		{Path: "a.txt", SHA256: strings.Repeat("a", 64)},
+	}
+	text := FormatSHA256Sums(files)
+	// Sorted by path.
+	if !strings.HasPrefix(text, strings.Repeat("a", 64)+"  a.txt\n") {
+		t.Fatalf("unexpected output order: %q", text)
+	}
+	parsed, err := ParseSHA256Sums(text)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed["a.txt"] != strings.Repeat("a", 64) || parsed["b.txt"] != strings.Repeat("b", 64) {
+		t.Fatalf("roundtrip mismatch: %+v", parsed)
+	}
+}
+
+func TestManifest_ValidateSchema(t *testing.T) {
+	m := &Manifest{SchemaVersion: SchemaVersion}
+	if err := m.ValidateSchema(); err != nil {
+		t.Fatalf("current schema must validate: %v", err)
+	}
+	m.SchemaVersion = 0
+	if err := m.ValidateSchema(); err == nil {
+		t.Fatal("missing schema_version must fail")
+	}
+	m.SchemaVersion = SchemaVersion + 99
+	if err := m.ValidateSchema(); err == nil {
+		t.Fatal("future schema_version must fail")
+	}
+}
+
+func TestWriteAndReadTarGz_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(dir, "out.tar.gz")
+	entries := []Entry{
+		{ArchivePath: ManifestName, Content: []byte(`{"k":"v"}`)},
+		{ArchivePath: "nested/dir/file.txt", SourcePath: src},
+	}
+	if err := WriteTarGz(archive, entries); err != nil {
+		t.Fatalf("write tar.gz: %v", err)
+	}
+	st, err := os.Stat(archive)
+	if err != nil || st.Size() == 0 {
+		t.Fatalf("archive not created: %v size=%d", err, st.Size())
+	}
+
+	ext := filepath.Join(dir, "ext")
+	names, err := ReadTarGz(archive, ext)
+	if err != nil {
+		t.Fatalf("read tar.gz: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("want 2 entries, got %d: %v", len(names), names)
+	}
+	got, err := os.ReadFile(filepath.Join(ext, "nested/dir/file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("payload mismatch: %q", got)
+	}
+}
+
+func TestWriteAndReadZip_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("zip-payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(dir, "out.zip")
+	entries := []Entry{
+		{ArchivePath: ManifestName, Content: []byte(`{}`)},
+		{ArchivePath: "reports/a.md", SourcePath: src},
+	}
+	if err := WriteZip(archive, entries); err != nil {
+		t.Fatalf("write zip: %v", err)
+	}
+	ext := filepath.Join(dir, "ext")
+	if _, err := ReadZip(archive, ext); err != nil {
+		t.Fatalf("read zip: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(ext, "reports/a.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "zip-payload" {
+		t.Fatalf("payload mismatch: %q", got)
+	}
+}
+
+func TestValidateArchivePath_RejectsTraversal(t *testing.T) {
+	cases := []string{
+		"",
+		"/abs/path",
+		"../escape",
+		"nested/../../etc/passwd",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			if err := validateArchivePath(p); err == nil {
+				t.Fatalf("path %q should be rejected", p)
+			}
+		})
+	}
+	ok := []string{"manifest.json", "snaps/abc/meta.json", "nested/dir/file.txt"}
+	for _, p := range ok {
+		if err := validateArchivePath(p); err != nil {
+			t.Fatalf("path %q should be accepted: %v", p, err)
+		}
+	}
+}

--- a/internal/bundle/checksums.go
+++ b/internal/bundle/checksums.go
@@ -1,0 +1,83 @@
+package bundle
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// SHA256File returns the hex-encoded SHA-256 digest of the file at path.
+func SHA256File(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // path comes from trusted callers enumerating local files
+	if err != nil {
+		return "", fmt.Errorf("sha256 open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("sha256 read %s: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// SHA256Bytes returns the hex-encoded SHA-256 digest of b.
+func SHA256Bytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// FormatSHA256Sums produces GNU-compatible SHA256SUMS text for files,
+// stable-sorted by archive path for reproducibility.
+func FormatSHA256Sums(files []File) string {
+	cp := make([]File, len(files))
+	copy(cp, files)
+	sort.Slice(cp, func(i, j int) bool { return cp[i].Path < cp[j].Path })
+
+	var b strings.Builder
+	for _, f := range cp {
+		// Two spaces between hash and filename is the canonical GNU
+		// coreutils sha256sum format (binary mode uses a single space+asterisk
+		// instead; we stick with portable text mode).
+		fmt.Fprintf(&b, "%s  %s\n", f.SHA256, f.Path)
+	}
+	return b.String()
+}
+
+// ParseSHA256Sums parses GNU-format SHA256SUMS text into a map keyed by
+// archive path.
+func ParseSHA256Sums(text string) (map[string]string, error) {
+	out := map[string]string{}
+	sc := bufio.NewScanner(strings.NewReader(text))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		// Format: "<hex>  <path>" (two spaces) or "<hex> *<path>" (binary).
+		var hash, path string
+		switch {
+		case strings.Contains(line, "  "):
+			parts := strings.SplitN(line, "  ", 2)
+			hash, path = parts[0], parts[1]
+		case strings.Contains(line, " *"):
+			parts := strings.SplitN(line, " *", 2)
+			hash, path = parts[0], parts[1]
+		default:
+			return nil, fmt.Errorf("sha256sums: malformed line %q", line)
+		}
+		if len(hash) != 64 {
+			return nil, fmt.Errorf("sha256sums: bad hash length in %q", line)
+		}
+		out[path] = hash
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("sha256sums: scan: %w", err)
+	}
+	return out, nil
+}

--- a/internal/bundle/doc.go
+++ b/internal/bundle/doc.go
@@ -1,0 +1,12 @@
+// Package bundle provides portable tar.gz and zip archive helpers with a
+// common manifest.json and SHA256SUMS layout used by `gotr export/import
+// snap` and `gotr export/import report`.
+//
+// A bundle contains:
+//   - manifest.json   — machine-readable metadata (schema version, gotr
+//     version, kind, file list with SHA-256 and relative-to-home paths).
+//   - SHA256SUMS      — GNU-format checksum file for external verification.
+//   - README.txt      — human-readable summary.
+//   - payload files   — archived with forward-slash paths and deterministic
+//     modes so bundles are reproducible across machines.
+package bundle

--- a/internal/bundle/entry.go
+++ b/internal/bundle/entry.go
@@ -1,0 +1,33 @@
+package bundle
+
+import (
+	"io/fs"
+	"time"
+)
+
+// Entry describes one archive entry queued for writing.
+//
+// Exactly one of SourcePath or Content must be non-zero:
+//   - SourcePath != ""  → file read from the local filesystem
+//   - Content   != nil  → in-memory bytes (useful for manifest/README/SHA256SUMS)
+type Entry struct {
+	// ArchivePath is the forward-slash path inside the archive. Must not be
+	// empty and must not start with "/".
+	ArchivePath string
+	// RelHome is the original location in ~/.gotr form; stored into the
+	// manifest. May be empty for virtual entries (manifest, README, SHA256SUMS).
+	RelHome string
+
+	SourcePath string
+	Content    []byte
+
+	Mode    fs.FileMode
+	ModTime time.Time
+}
+
+// defaultMode is the mode used when Entry.Mode is zero.
+const defaultMode fs.FileMode = 0o644
+
+// defaultTime returns a stable deterministic timestamp used when
+// Entry.ModTime is zero so bundles are reproducible.
+func defaultTime() time.Time { return time.Unix(0, 0).UTC() }

--- a/internal/bundle/manifest.go
+++ b/internal/bundle/manifest.go
@@ -1,0 +1,77 @@
+package bundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SchemaVersion is the current bundle schema version. Bumped on any
+// incompatible manifest change.
+const SchemaVersion = 1
+
+// Bundle layout filenames (forward-slash relative paths inside archives).
+const (
+	ManifestName  = "manifest.json"
+	ChecksumsName = "SHA256SUMS"
+	ReadmeName    = "README.txt"
+)
+
+// Kind identifies the type of payload carried by a bundle.
+type Kind string
+
+// Supported bundle kinds.
+const (
+	KindSnap    Kind = "snap"
+	KindReports Kind = "reports"
+)
+
+// File describes one archived payload file (manifest/checksums/readme
+// themselves are NOT listed here — only the user payload).
+type File struct {
+	// Path is the file path inside the archive (forward-slash, no leading
+	// slash). For snap bundles this is `snaps/<id>/...`; for reports it is
+	// `reports/<basename>`.
+	Path string `json:"path"`
+	// RelHome is the original location in ~/.gotr form, e.g.
+	// "~/.gotr/snaps/sync/20260413T143000_full_p48_to_p49/meta.json".
+	RelHome string `json:"rel_home"`
+	// SHA256 is the hex-encoded SHA-256 of the file's bytes.
+	SHA256 string `json:"sha256"`
+	// Size is the uncompressed byte size.
+	Size int64 `json:"size"`
+}
+
+// Manifest is the top-level bundle metadata stored at manifest.json.
+type Manifest struct {
+	SchemaVersion int       `json:"schema_version"`
+	Kind          Kind      `json:"kind"`
+	GotrVersion   string    `json:"gotr_version"`
+	GeneratedAt   time.Time `json:"generated_at"`
+	Files         []File    `json:"files"`
+
+	// Snap-specific (when Kind == KindSnap with a single snapshot).
+	SnapID   string   `json:"snap_id,omitempty"`
+	Redacted []string `json:"redacted_fields,omitempty"`
+
+	// Reports-specific. Left as zero value when irrelevant.
+	ReportCount int `json:"report_count,omitempty"`
+}
+
+// MarshalJSON returns stable indented JSON so manifests diff nicely.
+func (m *Manifest) MarshalJSON() ([]byte, error) {
+	type alias Manifest
+	return json.MarshalIndent((*alias)(m), "", "  ")
+}
+
+// ValidateSchema returns an error when the manifest's schema version is not
+// supported by the current build. The error message is actionable.
+func (m *Manifest) ValidateSchema() error {
+	if m.SchemaVersion == 0 {
+		return fmt.Errorf("bundle manifest: missing schema_version (corrupt or pre-v3.3 archive)")
+	}
+	if m.SchemaVersion > SchemaVersion {
+		return fmt.Errorf("bundle manifest: schema version %d is newer than supported %d — upgrade gotr", m.SchemaVersion, SchemaVersion)
+	}
+	return nil
+}

--- a/internal/bundle/tar.go
+++ b/internal/bundle/tar.go
@@ -1,0 +1,195 @@
+package bundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriteTarGz writes entries into destPath as a gzip-compressed tar archive.
+// The parent directory of destPath is created as needed.
+func WriteTarGz(destPath string, entries []Entry) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("tar.gz mkdir parent: %w", err)
+	}
+	f, err := os.Create(destPath) //nolint:gosec // callers pass validated paths under ~/.gotr/exports
+	if err != nil {
+		return fmt.Errorf("tar.gz create %s: %w", destPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+
+	for _, e := range entries {
+		if err := writeTarEntry(tw, e); err != nil {
+			_ = tw.Close()
+			_ = gz.Close()
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		_ = gz.Close()
+		return fmt.Errorf("tar close: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("gzip close: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("tar.gz close file: %w", err)
+	}
+	return nil
+}
+
+func writeTarEntry(tw *tar.Writer, e Entry) error {
+	if err := validateArchivePath(e.ArchivePath); err != nil {
+		return err
+	}
+	mode := e.Mode
+	if mode == 0 {
+		mode = defaultMode
+	}
+	mt := e.ModTime
+	if mt.IsZero() {
+		mt = defaultTime()
+	}
+
+	var size int64
+	switch {
+	case e.Content != nil:
+		size = int64(len(e.Content))
+	case e.SourcePath != "":
+		st, err := os.Stat(e.SourcePath)
+		if err != nil {
+			return fmt.Errorf("tar stat %s: %w", e.SourcePath, err)
+		}
+		size = st.Size()
+	default:
+		return fmt.Errorf("tar entry %q: neither Content nor SourcePath set", e.ArchivePath)
+	}
+
+	hdr := &tar.Header{
+		Name:    e.ArchivePath,
+		Mode:    int64(mode.Perm()),
+		Size:    size,
+		ModTime: mt,
+		Format:  tar.FormatPAX,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("tar header %s: %w", e.ArchivePath, err)
+	}
+
+	if e.Content != nil {
+		if _, err := tw.Write(e.Content); err != nil {
+			return fmt.Errorf("tar write %s: %w", e.ArchivePath, err)
+		}
+		return nil
+	}
+
+	src, err := os.Open(e.SourcePath) //nolint:gosec // callers pass trusted local paths
+	if err != nil {
+		return fmt.Errorf("tar open %s: %w", e.SourcePath, err)
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := io.Copy(tw, src); err != nil {
+		return fmt.Errorf("tar copy %s: %w", e.SourcePath, err)
+	}
+	return nil
+}
+
+// ReadTarGz extracts srcPath into destDir. It rejects entries containing
+// path traversal (".." segments or absolute paths) and refuses symlinks.
+// Returns the list of extracted archive paths (forward-slash) in archive
+// order.
+func ReadTarGz(srcPath, destDir string) ([]string, error) {
+	f, err := os.Open(srcPath) //nolint:gosec // import path is validated by caller
+	if err != nil {
+		return nil, fmt.Errorf("tar.gz open %s: %w", srcPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	return extractTar(tar.NewReader(gz), destDir)
+}
+
+func extractTar(tr *tar.Reader, destDir string) ([]string, error) {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("tar extract mkdir %s: %w", destDir, err)
+	}
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar next: %w", err)
+		}
+		if err := validateArchivePath(hdr.Name); err != nil {
+			return nil, err
+		}
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeRegA: //nolint:staticcheck // TypeRegA deprecated but still appears in older archives
+			if err := extractTarRegular(tr, hdr, destDir); err != nil {
+				return nil, err
+			}
+			names = append(names, hdr.Name)
+		case tar.TypeDir:
+			// Directories are recreated as needed when files are written.
+			continue
+		default:
+			return nil, fmt.Errorf("tar extract: unsupported entry type %c for %q", hdr.Typeflag, hdr.Name)
+		}
+	}
+	return names, nil
+}
+
+func extractTarRegular(tr *tar.Reader, hdr *tar.Header, destDir string) error {
+	target := filepath.Join(destDir, filepath.FromSlash(hdr.Name))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("tar extract mkdir %s: %w", filepath.Dir(target), err)
+	}
+	mode := hdr.FileInfo().Mode().Perm()
+	if mode == 0 {
+		mode = defaultMode
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode) //nolint:gosec // path validated above
+	if err != nil {
+		return fmt.Errorf("tar extract create %s: %w", target, err)
+	}
+	if _, err := io.Copy(out, tr); err != nil { //nolint:gosec // size bounded by tar header; gotr bundles are user-generated
+		_ = out.Close()
+		return fmt.Errorf("tar extract write %s: %w", target, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("tar extract close %s: %w", target, err)
+	}
+	return nil
+}
+
+// validateArchivePath rejects unsafe paths to prevent zip-slip style
+// attacks. Entries must be forward-slash, non-empty, and must not escape
+// the destination directory.
+func validateArchivePath(p string) error {
+	if p == "" {
+		return errors.New("archive entry has empty path")
+	}
+	if strings.HasPrefix(p, "/") || strings.HasPrefix(p, `\`) {
+		return fmt.Errorf("archive entry %q has absolute path", p)
+	}
+	clean := filepath.ToSlash(filepath.Clean(p))
+	if clean == ".." || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return fmt.Errorf("archive entry %q escapes archive root", p)
+	}
+	return nil
+}

--- a/internal/bundle/zip.go
+++ b/internal/bundle/zip.go
@@ -1,0 +1,137 @@
+package bundle
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// WriteZip writes entries to destPath as a standard .zip archive.
+func WriteZip(destPath string, entries []Entry) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("zip mkdir parent: %w", err)
+	}
+	f, err := os.Create(destPath) //nolint:gosec // trusted export directory
+	if err != nil {
+		return fmt.Errorf("zip create %s: %w", destPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+	for _, e := range entries {
+		if err := writeZipEntry(zw, e); err != nil {
+			_ = zw.Close()
+			return err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("zip close: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("zip close file: %w", err)
+	}
+	return nil
+}
+
+func writeZipEntry(zw *zip.Writer, e Entry) error {
+	if err := validateArchivePath(e.ArchivePath); err != nil {
+		return err
+	}
+	hdr := &zip.FileHeader{
+		Name:   e.ArchivePath,
+		Method: zip.Deflate,
+	}
+	mode := e.Mode
+	if mode == 0 {
+		mode = defaultMode
+	}
+	hdr.SetMode(mode)
+	mt := e.ModTime
+	if mt.IsZero() {
+		mt = defaultTime()
+	}
+	hdr.Modified = mt
+
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("zip header %s: %w", e.ArchivePath, err)
+	}
+
+	if e.Content != nil {
+		if _, err := w.Write(e.Content); err != nil {
+			return fmt.Errorf("zip write %s: %w", e.ArchivePath, err)
+		}
+		return nil
+	}
+	if e.SourcePath == "" {
+		return fmt.Errorf("zip entry %q: neither Content nor SourcePath set", e.ArchivePath)
+	}
+	src, err := os.Open(e.SourcePath) //nolint:gosec // trusted local path
+	if err != nil {
+		return fmt.Errorf("zip open %s: %w", e.SourcePath, err)
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := io.Copy(w, src); err != nil {
+		return fmt.Errorf("zip copy %s: %w", e.SourcePath, err)
+	}
+	return nil
+}
+
+// ReadZip extracts srcPath into destDir. Rejects unsafe paths.
+func ReadZip(srcPath, destDir string) ([]string, error) {
+	r, err := zip.OpenReader(srcPath)
+	if err != nil {
+		return nil, fmt.Errorf("zip open %s: %w", srcPath, err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("zip extract mkdir %s: %w", destDir, err)
+	}
+
+	var names []string
+	for _, zf := range r.File {
+		if err := validateArchivePath(zf.Name); err != nil {
+			return nil, err
+		}
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+		if err := extractZipFile(zf, destDir); err != nil {
+			return nil, err
+		}
+		names = append(names, zf.Name)
+	}
+	return names, nil
+}
+
+func extractZipFile(zf *zip.File, destDir string) error {
+	target := filepath.Join(destDir, filepath.FromSlash(zf.Name))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("zip extract mkdir %s: %w", filepath.Dir(target), err)
+	}
+	mode := zf.Mode().Perm()
+	if mode == 0 {
+		mode = defaultMode
+	}
+	src, err := zf.Open()
+	if err != nil {
+		return fmt.Errorf("zip open entry %s: %w", zf.Name, err)
+	}
+	defer func() { _ = src.Close() }()
+
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode) //nolint:gosec // path validated
+	if err != nil {
+		return fmt.Errorf("zip extract create %s: %w", target, err)
+	}
+	if _, err := io.Copy(out, src); err != nil { //nolint:gosec // bundles are user-generated
+		_ = out.Close()
+		return fmt.Errorf("zip extract write %s: %w", target, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("zip extract close %s: %w", target, err)
+	}
+	return nil
+}

--- a/internal/reportbundle/reportbundle.go
+++ b/internal/reportbundle/reportbundle.go
@@ -1,0 +1,296 @@
+// Package reportbundle implements portable zip export/import of gotr
+// migration reports (markdown/PDF/JSON) living in ~/.gotr/reports/.
+package reportbundle
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Korrnals/gotr/internal/bundle"
+	"github.com/Korrnals/gotr/internal/paths"
+)
+
+// ExportOptions configures report export.
+type ExportOptions struct {
+	GotrVersion string
+	// Filter is a glob (filepath.Match) applied to basenames. Empty = match all.
+	Filter string
+}
+
+// Result reports the outcome of an export or import.
+type Result struct {
+	// ArchivePath is the on-disk path written (zip for `all`, plain copy
+	// for a single file). For imports it is the source path.
+	ArchivePath string
+	// Copied is the list of files copied or extracted (absolute paths).
+	Copied []string
+	Files  []bundle.File
+}
+
+// ExportSingle copies a single report file from ~/.gotr/reports/ into
+// destPath. If destPath is empty, the report is copied under
+// ~/.gotr/exports/<basename>.
+func ExportSingle(reportsDir, reportName, destPath string) (*Result, error) {
+	src := filepath.Join(reportsDir, reportName)
+	st, err := os.Stat(src)
+	if err != nil {
+		return nil, fmt.Errorf("reportbundle: %w", err)
+	}
+	if st.IsDir() {
+		return nil, fmt.Errorf("reportbundle: %q is a directory", reportName)
+	}
+	if destPath == "" {
+		out, err := paths.EnsureExportsDirPath()
+		if err != nil {
+			return nil, err
+		}
+		destPath = filepath.Join(out, reportName)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return nil, fmt.Errorf("reportbundle: mkdir %s: %w", destPath, err)
+	}
+	if err := copyFile(src, destPath); err != nil {
+		return nil, err
+	}
+	return &Result{ArchivePath: destPath, Copied: []string{destPath}}, nil
+}
+
+// ExportAll bundles every report file under reportsDir (optionally filtered)
+// into a zip archive written to destPath. If destPath is empty, the archive
+// is written under ~/.gotr/exports/reports_<YYYYMMDD>.zip.
+func ExportAll(reportsDir, destPath string, opts ExportOptions) (*Result, error) {
+	selected, err := selectReports(reportsDir, opts.Filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(selected) == 0 {
+		return nil, errors.New("reportbundle: no reports matched")
+	}
+
+	if destPath == "" {
+		out, err := paths.EnsureExportsDirPath()
+		if err != nil {
+			return nil, err
+		}
+		destPath = filepath.Join(out, fmt.Sprintf("reports_%s.zip", time.Now().UTC().Format("20060102")))
+	}
+
+	entries, files, err := buildReportEntries(reportsDir, selected)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := &bundle.Manifest{
+		SchemaVersion: bundle.SchemaVersion,
+		Kind:          bundle.KindReports,
+		GotrVersion:   opts.GotrVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Files:         files,
+		ReportCount:   len(files),
+	}
+	manifestJSON, err := manifest.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("reportbundle: marshal manifest: %w", err)
+	}
+	entries = append(entries,
+		bundle.Entry{ArchivePath: bundle.ManifestName, Content: manifestJSON},
+		bundle.Entry{ArchivePath: bundle.ChecksumsName, Content: []byte(bundle.FormatSHA256Sums(files))},
+		bundle.Entry{ArchivePath: bundle.ReadmeName, Content: []byte(readmeReports(manifest))},
+	)
+
+	if err := bundle.WriteZip(destPath, entries); err != nil {
+		return nil, fmt.Errorf("reportbundle: write zip: %w", err)
+	}
+	return &Result{ArchivePath: destPath, Copied: nil, Files: files}, nil
+}
+
+func selectReports(reportsDir, filter string) ([]string, error) {
+	ents, err := os.ReadDir(reportsDir)
+	if err != nil {
+		return nil, fmt.Errorf("reportbundle: read %s: %w", reportsDir, err)
+	}
+	var selected []string
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		if filter != "" {
+			match, err := filepath.Match(filter, e.Name())
+			if err != nil {
+				return nil, fmt.Errorf("reportbundle: bad filter %q: %w", filter, err)
+			}
+			if !match {
+				continue
+			}
+		}
+		selected = append(selected, e.Name())
+	}
+	sort.Strings(selected)
+	return selected, nil
+}
+
+func buildReportEntries(reportsDir string, names []string) ([]bundle.Entry, []bundle.File, error) {
+	home, _ := os.UserHomeDir()
+	var entries []bundle.Entry
+	var files []bundle.File
+	for _, name := range names {
+		src := filepath.Join(reportsDir, name)
+		data, err := os.ReadFile(src) //nolint:gosec // reportsDir is controlled
+		if err != nil {
+			return nil, nil, fmt.Errorf("reportbundle: read %s: %w", src, err)
+		}
+		archive := "reports/" + name
+		entries = append(entries, bundle.Entry{
+			ArchivePath: archive,
+			RelHome:     relHome(home, src),
+			Content:     data,
+		})
+		files = append(files, bundle.File{
+			Path:    archive,
+			RelHome: relHome(home, src),
+			SHA256:  bundle.SHA256Bytes(data),
+			Size:    int64(len(data)),
+		})
+	}
+	return entries, files, nil
+}
+
+// ImportOptions controls how a report is imported.
+type ImportOptions struct {
+	Overwrite bool
+	DryRun    bool
+}
+
+// Import imports a single file (pdf/md/json) or a zip bundle of reports
+// into ~/.gotr/reports/. Returns the list of destination files.
+func Import(reportsDir, srcPath string, opts ImportOptions) (*Result, error) {
+	if err := os.MkdirAll(reportsDir, 0o755); err != nil {
+		return nil, fmt.Errorf("reportbundle: mkdir reports: %w", err)
+	}
+	ext := strings.ToLower(filepath.Ext(srcPath))
+	if ext == ".zip" {
+		return importZip(reportsDir, srcPath, opts)
+	}
+	return importSingle(reportsDir, srcPath, opts)
+}
+
+func importSingle(reportsDir, srcPath string, opts ImportOptions) (*Result, error) {
+	base := filepath.Base(srcPath)
+	dst := filepath.Join(reportsDir, base)
+	if _, err := os.Stat(dst); err == nil && !opts.Overwrite {
+		return nil, fmt.Errorf("reportbundle: %s already exists; use --overwrite", base)
+	}
+	if opts.DryRun {
+		return &Result{ArchivePath: srcPath, Copied: []string{dst}}, nil
+	}
+	if err := copyFile(srcPath, dst); err != nil {
+		return nil, err
+	}
+	return &Result{ArchivePath: srcPath, Copied: []string{dst}}, nil
+}
+
+func importZip(reportsDir, srcPath string, opts ImportOptions) (*Result, error) {
+	tmp, err := os.MkdirTemp("", "gotr-reports-import-*")
+	if err != nil {
+		return nil, fmt.Errorf("reportbundle: tmpdir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	if _, err := bundle.ReadZip(srcPath, tmp); err != nil {
+		return nil, fmt.Errorf("reportbundle: read zip: %w", err)
+	}
+	// Validate manifest (tolerate absence for backward-compat).
+	manifest, _ := parseManifest(filepath.Join(tmp, bundle.ManifestName))
+	if manifest != nil {
+		if err := manifest.ValidateSchema(); err != nil {
+			return nil, err
+		}
+		if manifest.Kind != bundle.KindReports && manifest.Kind != "" {
+			return nil, fmt.Errorf("reportbundle: unexpected bundle kind %q", manifest.Kind)
+		}
+	}
+
+	reportsSrc := filepath.Join(tmp, "reports")
+	ents, err := os.ReadDir(reportsSrc)
+	if err != nil {
+		return nil, fmt.Errorf("reportbundle: archive missing reports/: %w", err)
+	}
+
+	var copied []string
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		dst := filepath.Join(reportsDir, e.Name())
+		if _, err := os.Stat(dst); err == nil && !opts.Overwrite {
+			return nil, fmt.Errorf("reportbundle: %s already exists; use --overwrite", e.Name())
+		}
+		if opts.DryRun {
+			copied = append(copied, dst)
+			continue
+		}
+		if err := copyFile(filepath.Join(reportsSrc, e.Name()), dst); err != nil {
+			return nil, err
+		}
+		copied = append(copied, dst)
+	}
+	sort.Strings(copied)
+	return &Result{ArchivePath: srcPath, Copied: copied}, nil
+}
+
+func parseManifest(path string) (*bundle.Manifest, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is tmp dir
+	if err != nil {
+		return nil, err
+	}
+	var m bundle.Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src) //nolint:gosec // trusted local path
+	if err != nil {
+		return fmt.Errorf("reportbundle: open %s: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(dst) //nolint:gosec // trusted local path
+	if err != nil {
+		return fmt.Errorf("reportbundle: create %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("reportbundle: copy %s -> %s: %w", src, dst, err)
+	}
+	return out.Close()
+}
+
+func relHome(home, p string) string {
+	if home == "" {
+		return p
+	}
+	if rel, err := filepath.Rel(home, p); err == nil && !strings.HasPrefix(rel, "..") {
+		return "~/" + filepath.ToSlash(rel)
+	}
+	return p
+}
+
+func readmeReports(m *bundle.Manifest) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "gotr reports bundle\n")
+	fmt.Fprintf(&b, "generated_at: %s\n", m.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "gotr_version: %s\n", m.GotrVersion)
+	fmt.Fprintf(&b, "schema_version: %d\n", m.SchemaVersion)
+	fmt.Fprintf(&b, "report_count: %d\n", m.ReportCount)
+	fmt.Fprintf(&b, "\nImport with: gotr import report <file>.zip\n")
+	return b.String()
+}

--- a/internal/reportbundle/reportbundle_test.go
+++ b/internal/reportbundle/reportbundle_test.go
@@ -1,0 +1,119 @@
+package reportbundle
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func seedReports(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("content of "+n), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+func TestExportSingle_PlainCopy(t *testing.T) {
+	src := seedReports(t, "migration-2026-01-01.md")
+	dest := filepath.Join(t.TempDir(), "copy.md")
+	res, err := ExportSingle(src, "migration-2026-01-01.md", dest)
+	if err != nil {
+		t.Fatalf("ExportSingle: %v", err)
+	}
+	if res.ArchivePath != dest {
+		t.Errorf("archive = %s, want %s", res.ArchivePath, dest)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !strings.Contains(string(data), "migration-2026-01-01.md") {
+		t.Errorf("unexpected copied content: %s", data)
+	}
+}
+
+func TestExportAll_And_ImportZip_Roundtrip(t *testing.T) {
+	src := seedReports(t, "migration-2026-01-01.md", "migration-2026-01-01.pdf", "other.json")
+	dest := filepath.Join(t.TempDir(), "bundle.zip")
+
+	res, err := ExportAll(src, dest, ExportOptions{GotrVersion: "test"})
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+	if len(res.Files) != 3 {
+		t.Errorf("exported files = %d, want 3", len(res.Files))
+	}
+
+	// Import into a fresh reports dir.
+	freshReports := t.TempDir()
+	imp, err := Import(freshReports, dest, ImportOptions{})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if len(imp.Copied) != 3 {
+		t.Errorf("imported = %d, want 3", len(imp.Copied))
+	}
+	sort.Strings(imp.Copied)
+	for _, want := range []string{"migration-2026-01-01.md", "migration-2026-01-01.pdf", "other.json"} {
+		p := filepath.Join(freshReports, want)
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("missing imported file %s", want)
+		}
+	}
+}
+
+func TestExportAll_Filter_NarrowsSelection(t *testing.T) {
+	src := seedReports(t, "migration-a.md", "migration-b.md", "ignore.log")
+	dest := filepath.Join(t.TempDir(), "bundle.zip")
+	res, err := ExportAll(src, dest, ExportOptions{GotrVersion: "test", Filter: "migration-*.md"})
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+	if len(res.Files) != 2 {
+		t.Errorf("with filter expected 2 files, got %d", len(res.Files))
+	}
+}
+
+func TestImport_RefusesExistingWithoutOverwrite(t *testing.T) {
+	src := seedReports(t, "migration.md")
+	dest := filepath.Join(t.TempDir(), "bundle.zip")
+	if _, err := ExportAll(src, dest, ExportOptions{GotrVersion: "test"}); err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+
+	target := t.TempDir()
+	if err := os.WriteFile(filepath.Join(target, "migration.md"), []byte("existing"), 0o644); err != nil {
+		t.Fatalf("seed existing: %v", err)
+	}
+	if _, err := Import(target, dest, ImportOptions{}); err == nil {
+		t.Fatalf("expected conflict error, got nil")
+	}
+	if _, err := Import(target, dest, ImportOptions{Overwrite: true}); err != nil {
+		t.Fatalf("overwrite should succeed: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(target, "migration.md"))
+	if !strings.Contains(string(got), "content of migration.md") {
+		t.Errorf("overwrite did not replace contents: %s", got)
+	}
+}
+
+func TestImportSingle_DryRun_NoWrite(t *testing.T) {
+	src := seedReports(t, "migration.md")
+	target := t.TempDir()
+	res, err := Import(target, filepath.Join(src, "migration.md"), ImportOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("Import dry-run: %v", err)
+	}
+	if len(res.Copied) != 1 {
+		t.Errorf("expected 1 planned copy, got %d", len(res.Copied))
+	}
+	if _, err := os.Stat(filepath.Join(target, "migration.md")); err == nil {
+		t.Errorf("dry-run must not write file")
+	}
+}

--- a/internal/snapbundle/snapbundle.go
+++ b/internal/snapbundle/snapbundle.go
@@ -1,0 +1,464 @@
+// Package snapbundle implements portable tar.gz export/import of gotr
+// snapshots. It builds on internal/bundle for archive mechanics and on
+// internal/snap for on-disk snapshot layout.
+package snapbundle
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Korrnals/gotr/internal/bundle"
+	"github.com/Korrnals/gotr/internal/paths"
+	"github.com/Korrnals/gotr/internal/snap"
+)
+
+// ExportOptions controls snapshot export behavior.
+type ExportOptions struct {
+	// GotrVersion is recorded into manifest.json for reader context.
+	GotrVersion string
+	// Redact turns on redaction of known sensitive fields in meta.json
+	// (assignee_email, assignee, and top-level "email" keys). The list of
+	// redacted field paths is reported back in the returned Result.
+	Redact bool
+}
+
+// Result summarizes an export or import operation.
+type Result struct {
+	ArchivePath string
+	SnapID      string
+	Files       []bundle.File
+	Redacted    []string
+}
+
+// ExportOne writes the given snapshot into destPath (a .tar.gz file). The
+// snapshot directory at ~/.gotr/snaps/<id>/ is archived in full.
+func ExportOne(store *snap.Store, snapID, destPath string, opts ExportOptions) (*Result, error) {
+	if !store.Exists(snapID) {
+		return nil, fmt.Errorf("snapbundle: snapshot %q does not exist", snapID)
+	}
+	entries, files, redacted, err := collectEntries(store, snapID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := &bundle.Manifest{
+		SchemaVersion: bundle.SchemaVersion,
+		Kind:          bundle.KindSnap,
+		GotrVersion:   opts.GotrVersion,
+		GeneratedAt:   time.Now().UTC(),
+		SnapID:        snapID,
+		Files:         files,
+		Redacted:      redacted,
+	}
+	if err := appendMetaEntries(&entries, manifest); err != nil {
+		return nil, err
+	}
+
+	if err := bundle.WriteTarGz(destPath, entries); err != nil {
+		return nil, fmt.Errorf("snapbundle: write archive: %w", err)
+	}
+	return &Result{ArchivePath: destPath, SnapID: snapID, Files: files, Redacted: redacted}, nil
+}
+
+// collectEntries walks the snapshot directory and builds archive Entries +
+// manifest File descriptors. It also applies redaction when requested.
+func collectEntries(store *snap.Store, snapID string, opts ExportOptions) ([]bundle.Entry, []bundle.File, []string, error) {
+	snapDir := store.SnapDir(snapID)
+	home, _ := os.UserHomeDir()
+
+	var entries []bundle.Entry
+	var files []bundle.File
+	var redacted []string
+
+	err := filepath.WalkDir(snapDir, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(snapDir, p)
+		if err != nil {
+			return err
+		}
+		archivePath := "snaps/" + filepath.ToSlash(filepath.Join(snapID, rel))
+
+		content, redFields, err := readAndMaybeRedact(p, rel, opts.Redact)
+		if err != nil {
+			return err
+		}
+		redacted = append(redacted, redFields...)
+
+		sum := bundle.SHA256Bytes(content)
+		entries = append(entries, bundle.Entry{
+			ArchivePath: archivePath,
+			RelHome:     relHome(home, p),
+			Content:     content,
+		})
+		files = append(files, bundle.File{
+			Path:    archivePath,
+			RelHome: relHome(home, p),
+			SHA256:  sum,
+			Size:    int64(len(content)),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("snapbundle: walk %s: %w", snapDir, err)
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ArchivePath < entries[j].ArchivePath })
+	sort.Strings(redacted)
+	redacted = dedupe(redacted)
+
+	return entries, files, redacted, nil
+}
+
+// appendMetaEntries adds manifest.json, SHA256SUMS, and README.txt to entries.
+func appendMetaEntries(entries *[]bundle.Entry, manifest *bundle.Manifest) error {
+	manifestJSON, err := manifest.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("snapbundle: marshal manifest: %w", err)
+	}
+	sums := bundle.FormatSHA256Sums(manifest.Files)
+	readme := readmeSnap(manifest)
+
+	*entries = append(*entries,
+		bundle.Entry{ArchivePath: bundle.ManifestName, Content: manifestJSON},
+		bundle.Entry{ArchivePath: bundle.ChecksumsName, Content: []byte(sums)},
+		bundle.Entry{ArchivePath: bundle.ReadmeName, Content: []byte(readme)},
+	)
+	return nil
+}
+
+func readAndMaybeRedact(path, rel string, redact bool) (content []byte, redacted []string, err error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path enumerated from snap store
+	if err != nil {
+		return nil, nil, fmt.Errorf("snapbundle: read %s: %w", path, err)
+	}
+	if !redact {
+		return raw, nil, nil
+	}
+	// Only attempt redaction on JSON files. meta.json is the main target.
+	if filepath.Ext(rel) != ".json" {
+		return raw, nil, nil
+	}
+	var obj any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw, nil, nil
+	}
+	fields := redactSensitive(obj, "")
+	if len(fields) == 0 {
+		return raw, nil, nil
+	}
+	out, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return raw, nil, nil
+	}
+	return out, fields, nil
+}
+
+// sensitiveKeys lists JSON object keys that redactSensitive strips. Values
+// are replaced by "[redacted]" and the fully-qualified dotted path is
+// returned so operators can audit what left the machine.
+var sensitiveKeys = map[string]struct{}{
+	"assignee":       {},
+	"assignee_email": {},
+	"assignee_name":  {},
+	"email":          {},
+}
+
+func redactSensitive(node any, prefix string) []string {
+	var out []string
+	switch v := node.(type) {
+	case map[string]any:
+		for k, child := range v {
+			p := k
+			if prefix != "" {
+				p = prefix + "." + k
+			}
+			if _, hit := sensitiveKeys[k]; hit && child != nil {
+				v[k] = "[redacted]"
+				out = append(out, p)
+				continue
+			}
+			out = append(out, redactSensitive(child, p)...)
+		}
+	case []any:
+		for i, child := range v {
+			out = append(out, redactSensitive(child, fmt.Sprintf("%s[%d]", prefix, i))...)
+		}
+	}
+	return out
+}
+
+func dedupe(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func relHome(home, p string) string {
+	if home == "" {
+		return p
+	}
+	if rel, err := filepath.Rel(home, p); err == nil && !strings.HasPrefix(rel, "..") {
+		return "~/" + filepath.ToSlash(rel)
+	}
+	return p
+}
+
+func readmeSnap(m *bundle.Manifest) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "gotr snapshot bundle\n")
+	fmt.Fprintf(&b, "generated_at: %s\n", m.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "gotr_version: %s\n", m.GotrVersion)
+	fmt.Fprintf(&b, "schema_version: %d\n", m.SchemaVersion)
+	fmt.Fprintf(&b, "snap_id: %s\n", m.SnapID)
+	fmt.Fprintf(&b, "files: %d\n", len(m.Files))
+	if len(m.Redacted) > 0 {
+		fmt.Fprintf(&b, "redacted_fields: %s\n", strings.Join(m.Redacted, ", "))
+	}
+	fmt.Fprintf(&b, "\nExtract with: tar -xzf <file>.tar.gz\n")
+	fmt.Fprintf(&b, "Import with: gotr import snap <file>.tar.gz\n")
+	return b.String()
+}
+
+// DefaultExportPath returns the conventional export destination for a
+// snapshot, under ~/.gotr/exports/.
+func DefaultExportPath(snapID, label string) (string, error) {
+	dir, err := paths.EnsureExportsDirPath()
+	if err != nil {
+		return "", err
+	}
+	ts := time.Now().UTC().Format("20060102")
+	slug := sanitizeFilename(snapID)
+	if label != "" {
+		slug += "_" + sanitizeFilename(label)
+	}
+	return filepath.Join(dir, fmt.Sprintf("snap_%s_%s.tar.gz", slug, ts)), nil
+}
+
+func sanitizeFilename(s string) string {
+	r := strings.NewReplacer("/", "_", "\\", "_", ":", "_", " ", "_")
+	return r.Replace(s)
+}
+
+// ImportOptions controls how a bundle is imported.
+type ImportOptions struct {
+	Overwrite bool
+	RenameID  string // when set, import under this snap_id instead of the one in manifest
+	DryRun    bool
+}
+
+// Import extracts a snap bundle from srcPath into the local snap store.
+// Returns the effective snapshot ID and metadata about what was done.
+func Import(store *snap.Store, srcPath string, opts ImportOptions) (*Result, error) {
+	manifest, sums, err := peekManifest(srcPath)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.Kind != bundle.KindSnap {
+		return nil, fmt.Errorf("snapbundle: archive kind %q is not a snapshot bundle", manifest.Kind)
+	}
+	if err := verifyChecksums(manifest, sums); err != nil {
+		return nil, err
+	}
+	targetID := effectiveSnapID(manifest.SnapID, opts.RenameID)
+	if targetID == "" {
+		return nil, errors.New("snapbundle: manifest is missing snap_id")
+	}
+
+	if store.Exists(targetID) {
+		switch {
+		case opts.DryRun:
+			// fine — just report
+		case opts.Overwrite:
+			if err := backupExistingSnap(store, targetID); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("snapbundle: snapshot %q already exists; use --overwrite or --rename-id", targetID)
+		}
+	}
+
+	result := &Result{ArchivePath: srcPath, SnapID: targetID, Files: manifest.Files, Redacted: manifest.Redacted}
+	if opts.DryRun {
+		return result, nil
+	}
+
+	if err := extractAndRelocate(srcPath, store, manifest.SnapID, targetID); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func peekManifest(srcPath string) (*bundle.Manifest, string, error) {
+	tmp, err := os.MkdirTemp("", "gotr-snap-peek-*")
+	if err != nil {
+		return nil, "", fmt.Errorf("snapbundle: tmpdir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	if _, err := bundle.ReadTarGz(srcPath, tmp); err != nil {
+		return nil, "", fmt.Errorf("snapbundle: extract for peek: %w", err)
+	}
+	manifestBytes, err := os.ReadFile(filepath.Join(tmp, bundle.ManifestName))
+	if err != nil {
+		return nil, "", fmt.Errorf("snapbundle: read manifest: %w", err)
+	}
+	var m bundle.Manifest
+	if err := json.Unmarshal(manifestBytes, &m); err != nil {
+		return nil, "", fmt.Errorf("snapbundle: parse manifest: %w", err)
+	}
+	if err := m.ValidateSchema(); err != nil {
+		return nil, "", err
+	}
+	sumsBytes, _ := os.ReadFile(filepath.Join(tmp, bundle.ChecksumsName))
+	return &m, string(sumsBytes), nil
+}
+
+func verifyChecksums(m *bundle.Manifest, sumsText string) error {
+	if sumsText == "" {
+		// No external SHA256SUMS file; trust manifest.
+		return nil
+	}
+	parsed, err := bundle.ParseSHA256Sums(sumsText)
+	if err != nil {
+		return fmt.Errorf("snapbundle: bad SHA256SUMS: %w", err)
+	}
+	for _, f := range m.Files {
+		want, ok := parsed[f.Path]
+		if !ok {
+			return fmt.Errorf("snapbundle: SHA256SUMS missing entry for %s", f.Path)
+		}
+		if want != f.SHA256 {
+			return fmt.Errorf("snapbundle: checksum mismatch for %s (manifest=%s sums=%s)", f.Path, f.SHA256, want)
+		}
+	}
+	return nil
+}
+
+func effectiveSnapID(manifestID, rename string) string {
+	if rename != "" {
+		return rename
+	}
+	return manifestID
+}
+
+// backupExistingSnap moves ~/.gotr/snaps/<id> to ~/.gotr/snaps/.trash/<id>_<ts>/
+// so the user can recover a clobbered snapshot.
+func backupExistingSnap(store *snap.Store, snapID string) error {
+	trash := filepath.Join(store.BaseDir(), ".trash")
+	if err := os.MkdirAll(trash, 0o755); err != nil {
+		return fmt.Errorf("snapbundle: mkdir trash: %w", err)
+	}
+	src := store.SnapDir(snapID)
+	ts := time.Now().UTC().Format("20060102T150405")
+	dst := filepath.Join(trash, sanitizeFilename(snapID)+"_"+ts)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("snapbundle: mkdir backup parent: %w", err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("snapbundle: backup existing snap: %w", err)
+	}
+	return nil
+}
+
+// extractAndRelocate unpacks the archive to a temp dir and moves the
+// snapshot subtree into the store, optionally under a renamed id.
+func extractAndRelocate(srcPath string, store *snap.Store, archiveID, targetID string) error {
+	tmp, err := os.MkdirTemp("", "gotr-snap-import-*")
+	if err != nil {
+		return fmt.Errorf("snapbundle: tmpdir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	if _, err := bundle.ReadTarGz(srcPath, tmp); err != nil {
+		return fmt.Errorf("snapbundle: extract: %w", err)
+	}
+	srcSnap := filepath.Join(tmp, "snaps", filepath.FromSlash(archiveID))
+	if _, err := os.Stat(srcSnap); err != nil {
+		return fmt.Errorf("snapbundle: extracted archive missing snaps/%s: %w", archiveID, err)
+	}
+	dst := store.SnapDir(targetID)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("snapbundle: mkdir target parent: %w", err)
+	}
+	// If target still exists (e.g. --rename-id target clashes unexpectedly), fail.
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("snapbundle: target %s already exists", dst)
+	}
+	if err := os.Rename(srcSnap, dst); err != nil {
+		// os.Rename may fail across filesystems; fall back to copy+remove.
+		if err := copyTree(srcSnap, dst); err != nil {
+			return fmt.Errorf("snapbundle: relocate %s -> %s: %w", srcSnap, dst, err)
+		}
+	}
+	if targetID != archiveID {
+		if err := rewriteMetaID(dst, targetID); err != nil {
+			return fmt.Errorf("snapbundle: rewrite meta.json id: %w", err)
+		}
+	}
+	return nil
+}
+
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(src, p)
+		if rerr != nil {
+			return rerr
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, rerr := os.ReadFile(p) //nolint:gosec // source is our own tmp dir
+		if rerr != nil {
+			return rerr
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644) //nolint:gosec // restoring user-owned data
+	})
+}
+
+func rewriteMetaID(dir, newID string) error {
+	p := filepath.Join(dir, "meta.json")
+	raw, err := os.ReadFile(p) //nolint:gosec // dir is inside snap store
+	if err != nil {
+		return err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return err
+	}
+	m["id"] = newID
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, out, 0o644) //nolint:gosec // meta.json under trusted ~/.gotr/snaps path
+}

--- a/internal/snapbundle/snapbundle_test.go
+++ b/internal/snapbundle/snapbundle_test.go
@@ -1,0 +1,233 @@
+package snapbundle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Korrnals/gotr/internal/bundle"
+	"github.com/Korrnals/gotr/internal/snap"
+)
+
+// newStoreWithSnap creates an isolated snap store at t.TempDir() and seeds a
+// fake snapshot at "sync/<name>" with meta.json + data.json that includes
+// assignee_email so redaction can be verified.
+func newStoreWithSnap(t *testing.T) (*snap.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := snap.NewStoreAt(dir)
+	if err != nil {
+		t.Fatalf("NewStoreAt: %v", err)
+	}
+	snapID := "sync/20260101T000000_full_p1_to_p2"
+	meta := map[string]any{
+		"id":             snapID,
+		"label":          "unit",
+		"category":       "sync",
+		"operation":      "sync_full",
+		"entity_type":    "run",
+		"entity_ids":     []int{1},
+		"project_id":     1,
+		"dst_project_id": 2,
+		"timestamp":      time.Now().UTC().Format(time.RFC3339),
+		"status":         "success",
+		"data_file":      "data.json",
+		"assignee_email": "alice@example.com",
+	}
+	data := map[string]any{
+		"runs": []map[string]any{
+			{"id": 1, "assignee": "alice", "assignee_email": "alice@example.com"},
+		},
+	}
+	snapDir := filepath.Join(dir, "sync", "20260101T000000_full_p1_to_p2")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatalf("mkdir snap: %v", err)
+	}
+	writeJSON(t, filepath.Join(snapDir, "meta.json"), meta)
+	writeJSON(t, filepath.Join(snapDir, "data.json"), data)
+	return store, snapID
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestExportOne_And_ImportRoundtrip(t *testing.T) {
+	store, snapID := newStoreWithSnap(t)
+	dest := filepath.Join(t.TempDir(), "snap.tar.gz")
+
+	res, err := ExportOne(store, snapID, dest, ExportOptions{GotrVersion: "test"})
+	if err != nil {
+		t.Fatalf("ExportOne: %v", err)
+	}
+	if res.ArchivePath != dest {
+		t.Errorf("archive path = %s, want %s", res.ArchivePath, dest)
+	}
+	if len(res.Files) < 2 {
+		t.Errorf("expected ≥2 files in manifest, got %d", len(res.Files))
+	}
+
+	// Import into a fresh store.
+	freshDir := t.TempDir()
+	fresh, err := snap.NewStoreAt(freshDir)
+	if err != nil {
+		t.Fatalf("fresh store: %v", err)
+	}
+	imp, err := Import(fresh, dest, ImportOptions{})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if imp.SnapID != snapID {
+		t.Errorf("imported snap_id = %q, want %q", imp.SnapID, snapID)
+	}
+	if !fresh.Exists(snapID) {
+		t.Errorf("expected snapshot %s in fresh store", snapID)
+	}
+}
+
+func TestExportOne_Redact_StripsAssigneeEmail(t *testing.T) {
+	store, snapID := newStoreWithSnap(t)
+	dest := filepath.Join(t.TempDir(), "snap.tar.gz")
+
+	res, err := ExportOne(store, snapID, dest, ExportOptions{GotrVersion: "test", Redact: true})
+	if err != nil {
+		t.Fatalf("ExportOne redact: %v", err)
+	}
+	found := false
+	for _, f := range res.Redacted {
+		if strings.Contains(f, "assignee_email") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected redacted list to include assignee_email, got %v", res.Redacted)
+	}
+
+	// Extract and confirm redacted value is in meta.json.
+	tmp := t.TempDir()
+	if _, err := bundle.ReadTarGz(dest, tmp); err != nil {
+		t.Fatalf("ReadTarGz: %v", err)
+	}
+	metaPath := filepath.Join(tmp, "snaps", filepath.FromSlash(snapID), "meta.json")
+	raw, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	if !strings.Contains(string(raw), "[redacted]") {
+		t.Errorf("expected [redacted] marker in meta.json, got: %s", string(raw))
+	}
+	if strings.Contains(string(raw), "alice@example.com") {
+		t.Errorf("assignee_email leaked in redacted export: %s", string(raw))
+	}
+}
+
+func TestImport_RenameID(t *testing.T) {
+	store, snapID := newStoreWithSnap(t)
+	dest := filepath.Join(t.TempDir(), "snap.tar.gz")
+	if _, err := ExportOne(store, snapID, dest, ExportOptions{GotrVersion: "test"}); err != nil {
+		t.Fatalf("ExportOne: %v", err)
+	}
+	fresh, _ := snap.NewStoreAt(t.TempDir())
+	newID := "sync/renamed_id"
+	imp, err := Import(fresh, dest, ImportOptions{RenameID: newID})
+	if err != nil {
+		t.Fatalf("Import rename: %v", err)
+	}
+	if imp.SnapID != newID {
+		t.Errorf("imported id = %q, want %q", imp.SnapID, newID)
+	}
+	if !fresh.Exists(newID) {
+		t.Errorf("renamed snap missing on disk")
+	}
+	// meta.json must reflect the new id.
+	metaRaw, err := os.ReadFile(filepath.Join(fresh.SnapDir(newID), "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		t.Fatalf("parse meta: %v", err)
+	}
+	if got := meta["id"]; got != newID {
+		t.Errorf("meta.id = %v, want %s", got, newID)
+	}
+}
+
+func TestImport_RefusesExisting_WithoutOverwrite(t *testing.T) {
+	store, snapID := newStoreWithSnap(t)
+	dest := filepath.Join(t.TempDir(), "snap.tar.gz")
+	if _, err := ExportOne(store, snapID, dest, ExportOptions{GotrVersion: "test"}); err != nil {
+		t.Fatalf("ExportOne: %v", err)
+	}
+	if _, err := Import(store, dest, ImportOptions{}); err == nil {
+		t.Fatalf("expected Import to fail against existing snapshot, got nil error")
+	}
+}
+
+func TestImport_OverwriteBacksUpToTrash(t *testing.T) {
+	store, snapID := newStoreWithSnap(t)
+	dest := filepath.Join(t.TempDir(), "snap.tar.gz")
+	if _, err := ExportOne(store, snapID, dest, ExportOptions{GotrVersion: "test"}); err != nil {
+		t.Fatalf("ExportOne: %v", err)
+	}
+	if _, err := Import(store, dest, ImportOptions{Overwrite: true}); err != nil {
+		t.Fatalf("Import overwrite: %v", err)
+	}
+	trash := filepath.Join(store.BaseDir(), ".trash")
+	ents, err := os.ReadDir(trash)
+	if err != nil {
+		t.Fatalf("read trash: %v", err)
+	}
+	if len(ents) == 0 {
+		t.Errorf("expected backup in %s, found none", trash)
+	}
+}
+
+func TestImport_DryRun_NoMutation(t *testing.T) {
+	store, snapID := newStoreWithSnap(t)
+	dest := filepath.Join(t.TempDir(), "snap.tar.gz")
+	if _, err := ExportOne(store, snapID, dest, ExportOptions{GotrVersion: "test"}); err != nil {
+		t.Fatalf("ExportOne: %v", err)
+	}
+	fresh, _ := snap.NewStoreAt(t.TempDir())
+	res, err := Import(fresh, dest, ImportOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if res.SnapID != snapID {
+		t.Errorf("dry-run snap_id = %s, want %s", res.SnapID, snapID)
+	}
+	if fresh.Exists(snapID) {
+		t.Errorf("dry-run must not write snapshot to store")
+	}
+}
+
+func TestImport_SchemaVersionMismatch_Rejected(t *testing.T) {
+	// Build a handcrafted bad bundle: manifest schema_version = 999.
+	tmp := t.TempDir()
+	m := bundle.Manifest{SchemaVersion: 999, Kind: bundle.KindSnap, SnapID: "x/y"}
+	mj, _ := m.MarshalJSON()
+	archive := filepath.Join(tmp, "bad.tar.gz")
+	entries := []bundle.Entry{
+		{ArchivePath: bundle.ManifestName, Content: mj},
+		{ArchivePath: bundle.ChecksumsName, Content: []byte("")},
+	}
+	if err := bundle.WriteTarGz(archive, entries); err != nil {
+		t.Fatalf("WriteTarGz: %v", err)
+	}
+	store, _ := snap.NewStoreAt(t.TempDir())
+	if _, err := Import(store, archive, ImportOptions{}); err == nil {
+		t.Fatalf("expected schema version error, got nil")
+	}
+}


### PR DESCRIPTION
Closes #42, closes #43.

## Summary

Delivers the last two release-blocking items for v3.3.0: portable tar.gz / zip bundles for gotr snapshots and migration reports, SHA-256 verified, schema-versioned, and safe to share across machines.

## New commands

| Command | Default output | Notable flags |
|---|---|---|
| `gotr export snap <id\|label>` | `~/.gotr/exports/snap_<id>_<label>_<YYYYMMDD>.tar.gz` | `--out`, `--redact` |
| `gotr export report <file>` | `~/.gotr/exports/<basename>` (plain copy) | `--out` |
| `gotr export report all` | `~/.gotr/exports/reports_<YYYYMMDD>.zip` | `--out`, `--filter <glob>` |
| `gotr import snap <path.tar.gz>` | extracts to `~/.gotr/snaps/<id>/` | `--overwrite`, `--rename-id`, `--dry-run` |
| `gotr import report <path>` | copies / unzips into `~/.gotr/reports/` | `--overwrite`, `--dry-run` |
| `gotr report show <file\|latest>` | opens PDF via `xdg-open`/`open`/`rundll32`; cats MD/JSON/TXT | — |
| `gotr report list --filter <glob>` | filter by glob; now accepts `.pdf`/`.json` too | `--limit` |

## Bundle format (schema_version = 1)

Every archive contains:
- `manifest.json` — `schema_version`, `kind` (`snap`/`reports`), gotr version, `generated_at`, per-file list with `~/.gotr/...` relative paths and SHA-256
- `SHA256SUMS` — GNU two-space format
- `README.txt` — human-readable summary
- Payload: `snaps/<id>/...` (tar.gz) or `reports/<files>` (zip)

Archives are deterministic (fixed ModTime, stable entry ordering) so that identical input yields byte-identical output.

## Safety

- `validateArchivePath` rejects absolute paths, `..` traversal, and empty entries on both read/write (zip-slip hardening)
- Symlinks and non-regular tar entries are refused on extraction
- `--overwrite` on snap import backs up the existing snapshot to `~/.gotr/snaps/.trash/<id>_<ts>/` instead of silently clobbering
- `--redact` on snap export strips known sensitive JSON keys (`assignee`, `assignee_email`, `assignee_name`, `email`) and records their dotted paths in `manifest.redacted_fields`
- Schema version mismatches refuse the import with an actionable error
- Cross-filesystem imports fall back to copy-tree when `os.Rename` cannot move across mounts

## New internal packages

- `internal/bundle` — shared tar.gz + zip + SHA-256 + manifest primitives
- `internal/snapbundle` — snapshot-specific export/import with redaction, rename-id, trash-backup, dry-run
- `internal/reportbundle` — report-specific export/import (zip bundle or plain copy)

## Tests

- 6 tests in `internal/bundle/bundle_test.go` covering round-trip, checksums, schema validation, path traversal rejection
- 7 tests in `internal/snapbundle/snapbundle_test.go` covering export→import round-trip, redaction, rename-id, overwrite-to-trash, existing-refusal, dry-run, schema version mismatch
- 5 tests in `internal/reportbundle/reportbundle_test.go` covering plain copy, zip round-trip, glob filter, conflict refusal, dry-run
- Full suite `go test ./... -count=1 -timeout 300s`: green
- `make lint` (golangci-lint v2.11.4, CI-parity): `0 issues`

## Next steps

After merge into `release-3.3.0`, planned E2E validation on SRC=48 / DST=49:
1. `gotr sync full --src 48 --dst 49 --pdf-report`
2. `gotr export snap <id>` → remove → `gotr import snap <tarball>` → `gotr snap rollback --dry-run <id>`
3. `gotr export report all` → remove reports → `gotr import report <zip>` → `gotr report list` → `gotr report show <file>`
