### PR TITLE
chore(version): bump to 3.3.0 (pre-release)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// Version is populated at build time via -ldflags.
-	Version = "3.3.0-dev" // default value for local development
+	Version = "3.3.0" // default value for local development
 	Commit  = "unknown"
 	Date    = "unknown"
 	userHomeDir = os.UserHomeDir


### PR DESCRIPTION
Removes `-dev` suffix from `cmd/root.go` default Version ahead of the v3.3.0 tag.

Release workflow overrides Version via `-ldflags` on tag builds; this value only affects local `go build` without ldflags.

Gates:
- `go build ./...` — clean
- `./gotr --version` → `gotr version 3.3.0`

Refs: #44