### PR TITLE
chore: post-release bookkeeping for v3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,21 @@
 # gotr — CLI Client for TestRail API
 
-```text
-╔══════════════════════════════════════════════════════════╗
-║                                                          ║
-║     ██████╗  ██████╗ ████████╗██████╗                    ║
-║    ██╔════╝ ██╔═══██╗╚══██╔══╝██╔══██╗                   ║
-║    ██║  ███╗██║   ██║   ██║   ██████╔╝                   ║
-║    ██║   ██║██║   ██║   ██║   ██╔══██╗                   ║
-║    ╚██████╔╝╚██████╔╝   ██║   ██║  ██║                   ║
-║     ╚═════╝  ╚═════╝    ╚═╝   ╚═╝  ╚═╝                   ║
-║                                                          ║
-║           CLI Client for TestRail API v2                 ║
-║                                                          ║
-╚══════════════════════════════════════════════════════════╝
-```
+<p align="center">
+  <img src="docs/assets/banner.svg" alt="gotr — CLI client for TestRail API v2: migrate · snapshot · sync · report · automate" width="100%"/>
+</p>
 
 [English](README.md) | [Русский](README_ru.md)
 
-[![Latest Release](https://img.shields.io/badge/release-v3.3.2-blue.svg)](https://github.com/Korrnals/gotr/releases/tag/v3.3.2)
-[![Next](https://img.shields.io/badge/next-v3.4.0--dev-orange.svg)](CHANGELOG.md)
+[![Latest Release](https://img.shields.io/badge/release-v3.4.0-blue.svg)](https://github.com/Korrnals/gotr/releases/tag/v3.4.0)
+[![Next](https://img.shields.io/badge/next-v3.5.0--dev-orange.svg)](CHANGELOG.md)
 [![Go Version](https://img.shields.io/badge/go-1.25.0-blue.svg)](go.mod)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 A professional command-line interface for TestRail API v2. Designed for QA engineers and test automation specialists who need efficient data management, migration capabilities, and seamless integration with CI/CD pipelines.
 
-> **Latest Release:** [v3.3.2](https://github.com/Korrnals/gotr/releases/tag/v3.3.2).
+> **Latest Release:** [v3.4.0](https://github.com/Korrnals/gotr/releases/tag/v3.4.0) — multi-snap migration bundles, full-state cross-machine transfer, and store-manifest auto-registration on import.
 >
-> **In progress (`main`, untagged):** `v3.4.0-dev` — continues post-`v3.3.0`
-> development, including the  recovery track and follow-up snapshot
-> manifest hardening. See [CHANGELOG](CHANGELOG.md) for the current unreleased
-> scope.
+> **`main` currently points at tag [`v3.4.0`](https://github.com/Korrnals/gotr/releases/tag/v3.4.0)** and is in development toward `v3.5.0-dev` — see [CHANGELOG](CHANGELOG.md) for the unreleased scope.
 
 ## Overview
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -1,35 +1,21 @@
 # gotr — CLI-клиент для TestRail API
 
-```text
-╔══════════════════════════════════════════════════════════╗
-║                                                          ║
-║     ██████╗  ██████╗ ████████╗██████╗                    ║
-║    ██╔════╝ ██╔═══██╗╚══██╔══╝██╔══██╗                   ║
-║    ██║  ███╗██║   ██║   ██║   ██████╔╝                   ║
-║    ██║   ██║██║   ██║   ██║   ██╔══██╗                   ║
-║    ╚██████╔╝╚██████╔╝   ██║   ██║  ██║                   ║
-║     ╚═════╝  ╚═════╝    ╚═╝   ╚═╝  ╚═╝                   ║
-║                                                          ║
-║           CLI Client for TestRail API v2                 ║
-║                                                          ║
-╚══════════════════════════════════════════════════════════╝
-```
+<p align="center">
+  <img src="docs/assets/banner.svg" alt="gotr — CLI-клиент для TestRail API v2: миграция · снапшоты · синхронизация · отчёты · автоматизация" width="100%"/>
+</p>
 
 [English](README.md) | [Русский](README_ru.md)
 
-[![Latest Release](https://img.shields.io/badge/release-v3.3.2-blue.svg)](https://github.com/Korrnals/gotr/releases/tag/v3.3.2)
-[![Next](https://img.shields.io/badge/next-v3.4.0--dev-orange.svg)](CHANGELOG.md)
+[![Latest Release](https://img.shields.io/badge/release-v3.4.0-blue.svg)](https://github.com/Korrnals/gotr/releases/tag/v3.4.0)
+[![Next](https://img.shields.io/badge/next-v3.5.0--dev-orange.svg)](CHANGELOG.md)
 [![Go Version](https://img.shields.io/badge/go-1.25.0-blue.svg)](go.mod)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 Профессиональный инструмент командной строки для работы с TestRail API v2. Разработан для QA-инженеров и специалистов по автоматизации тестирования, которым требуется эффективное управление данными, возможности миграции и бесшовная интеграция с CI/CD.
 
-> **Последний релиз:** [v3.3.2](https://github.com/Korrnals/gotr/releases/tag/v3.3.2).
+> **Последний релиз:** [v3.4.0](https://github.com/Korrnals/gotr/releases/tag/v3.4.0) — мульти-снап миграционные бандлы, полный перенос состояния между машинами и авто-регистрация снапшотов в манифесте стора при импорте.
 >
-> **В работе (`main`, без тега):** `v3.4.0-dev` — это продолжение разработки
-> после `v3.3.0`, включая recovery-трек  и последующее укрепление
-> работы со snapshot-manifest. Полный unreleased-скоуп см. в
-> [CHANGELOG](CHANGELOG.md).
+> **`main` сейчас указывает на тег [`v3.4.0`](https://github.com/Korrnals/gotr/releases/tag/v3.4.0)** и развивается в сторону `v3.5.0-dev` — текущий unreleased-скоуп см. в [CHANGELOG](CHANGELOG.md).
 
 ## Обзор
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// Version is populated at build time via -ldflags.
-	Version = "3.4.0-dev" // default value for local development
+	Version = "3.5.0-dev" // default value for local development
 	Commit  = "unknown"
 	Date    = "unknown"
 	userHomeDir = os.UserHomeDir

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" role="img" aria-label="gotr — CLI Client for TestRail API v2">
+  <title>gotr — CLI Client for TestRail API v2</title>
+  <desc>Banner for the gotr command-line tool: TestRail API client with full resource CRUD, project migration, sync, diff/compare, snapshots, and migration reports.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"  stop-color="#0B1220"/>
+      <stop offset="55%" stop-color="#0F2A3A"/>
+      <stop offset="100%" stop-color="#0A3A4A"/>
+    </linearGradient>
+
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"  stop-color="#00ADD8"/>
+      <stop offset="100%" stop-color="#5DE0E6"/>
+    </linearGradient>
+
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="3" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <pattern id="dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1" fill="#FFFFFF" fill-opacity="0.05"/>
+    </pattern>
+
+    <symbol id="pill" overflow="visible">
+      <rect x="0" y="0" rx="18" ry="18" width="220" height="36"
+            fill="#0E2230" stroke="#1F4A5C" stroke-width="1"/>
+    </symbol>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="420" fill="url(#bg)"/>
+  <rect width="1200" height="420" fill="url(#dots)"/>
+
+  <!-- Terminal window chrome -->
+  <g transform="translate(40,40)">
+    <rect x="0" y="0" width="1120" height="340" rx="14" ry="14"
+          fill="#0A1A24" stroke="#1B3B4C" stroke-width="1.5"/>
+    <rect x="0" y="0" width="1120" height="34" rx="14" ry="14" fill="#0E2230"/>
+    <rect x="0" y="22" width="1120" height="14" fill="#0E2230"/>
+    <circle cx="22" cy="17" r="6" fill="#FF5F57"/>
+    <circle cx="44" cy="17" r="6" fill="#FEBC2E"/>
+    <circle cx="66" cy="17" r="6" fill="#28C840"/>
+    <text x="560" y="22" text-anchor="middle"
+          font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+          font-size="13" fill="#7FA9BB">~/projects/testrail — gotr</text>
+  </g>
+
+  <!-- Wordmark "gotr" -->
+  <g transform="translate(80,160)" filter="url(#glow)"
+     font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+     font-weight="700">
+    <text x="0" y="0" font-size="120" fill="url(#accent)" letter-spacing="-2">gotr</text>
+    <rect x="305" y="-78" width="22" height="84" fill="#5DE0E6">
+      <animate attributeName="opacity" values="1;1;0;0" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+
+  <!-- Prompt + tagline -->
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="80" y="205" font-size="18" fill="#5DE0E6" font-weight="700">$</text>
+    <text x="100" y="205" font-size="18" fill="#C7E7F2">
+      gotr <tspan fill="#7FA9BB">— CLI client for</tspan> TestRail API v2
+    </text>
+    <text x="80" y="235" font-size="14" fill="#6E96A8">
+      resources · migrate · sync · compare · snapshot · report · automate
+    </text>
+  </g>
+
+  <!-- Feature pills (right column, 2 cols × 4 rows) -->
+  <g transform="translate(700,90)"
+     font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif">
+    <g transform="translate(0,0)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#00ADD8"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">121 API endpoints · v2</text>
+    </g>
+    <g transform="translate(240,0)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#5DE0E6"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">Resource CRUD · 20+ entities</text>
+    </g>
+
+    <g transform="translate(0,52)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#28C840"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">Project sync &amp; migration</text>
+    </g>
+    <g transform="translate(240,52)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#FEBC2E"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">Diff &amp; compare projects</text>
+    </g>
+
+    <g transform="translate(0,104)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#7DD3FC"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">Snapshots · safe rollback</text>
+    </g>
+    <g transform="translate(240,104)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#FF5F57"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">Cross-machine bundles</text>
+    </g>
+
+    <g transform="translate(0,156)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#F472B6"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">Migration reports · PDF</text>
+    </g>
+    <g transform="translate(240,156)">
+      <use href="#pill"/>
+      <circle cx="20" cy="18" r="6" fill="#A78BFA"/>
+      <text x="38" y="23" font-size="13" fill="#C7E7F2" font-weight="600">CI/CD friendly · scriptable</text>
+    </g>
+  </g>
+
+  <!-- Bottom command strip -->
+  <g transform="translate(80,346)"
+     font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+     font-size="13">
+    <rect x="0" y="0" width="1040" height="38" rx="8" fill="#081521" stroke="#1B3B4C"/>
+    <text x="16" y="24" fill="#5DE0E6" font-weight="700">›</text>
+    <text x="36" y="24">
+      <tspan fill="#C7E7F2">gotr</tspan>
+      <tspan fill="#7FA9BB"> get </tspan>
+      <tspan fill="#C7E7F2">cases</tspan>
+      <tspan fill="#7FA9BB">  |  </tspan>
+      <tspan fill="#C7E7F2">gotr</tspan>
+      <tspan fill="#7FA9BB"> sync </tspan>
+      <tspan fill="#C7E7F2">cases --src 48 --dst 49</tspan>
+      <tspan fill="#7FA9BB">  |  </tspan>
+      <tspan fill="#C7E7F2">gotr</tspan>
+      <tspan fill="#7FA9BB"> compare </tspan>
+      <tspan fill="#C7E7F2">all</tspan>
+      <tspan fill="#7FA9BB">  |  </tspan>
+      <tspan fill="#C7E7F2">gotr</tspan>
+      <tspan fill="#7FA9BB"> snap </tspan>
+      <tspan fill="#C7E7F2">create</tspan>
+      <tspan fill="#7FA9BB">  |  </tspan>
+      <tspan fill="#C7E7F2">gotr</tspan>
+      <tspan fill="#7FA9BB"> report </tspan>
+      <tspan fill="#C7E7F2">show</tspan>
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
Post-release bookkeeping after v3.4.0 was tagged on `main` (commit `dab2eaf`).

### Changes
- **README.md / README_ru.md** — bump 'Latest Release' badge & note to **v3.4.0** (link to GitHub release tag); update 'In progress' marker to `v3.4.1-dev`.
- **cmd/root.go** — bump dev `Version` to `3.4.1-dev` per [RELEASE.md §6](.github/instructions/workflow/RELEASE.md) discipline (main always carries a dev marker between releases).

### Validation
- `go build ./...` — OK

Tag `v3.4.0` is already published at `dab2eaf`; this PR only updates docs/dev-marker.