### PR TITLE
fix(cleanup): scanner picks up run/result-bound attachments (v3.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,42 @@ _No unreleased changes yet._
 
 ---
 
+## [3.5.2] - 2026-05-05
+
+### Fixed — entity scanner: complete coverage of run/result attachments
+
+- **Run-bound attachments are no longer dropped.** TestRail Server
+  builds (notably self-hosted < 7.5) return
+  `get_attachments_for_run/{id}` payloads with `run_id`/`case_id`/
+  `result_id` set to `null`. The previous scanner relied on those
+  fields, so `InferredEntityType()` returned an empty string and
+  `--entity-type run` filtered every run-bound attachment out. The
+  scanner now stamps the parent ID after each per-entity fetch.
+- **Result-/test-bound attachments are now scanned.** The entity
+  scanner only walked `cases → runs → plans`; result-bound files were
+  reachable solely via `get_attachments_for_test/{test_id}` and were
+  silently skipped. A new tests walk enumerates every run
+  (project-level + plan entries) → tests → attachments, and
+  `--entity-type result|test` now route to it.
+- **Mapping change:** `EntityScannerOptionsFromTypes` no longer
+  conflates `result`/`test` with the case walk. The new
+  `EntityScannerOptions.WalkTests` flag drives the dedicated walk.
+  Default behavior (no `--entity-type` filter) walks **all four**
+  kinds (cases, runs, plans, tests). v3.5.1 is impacted; deletion
+  runs that omitted `--entity-type` would have missed run/result
+  attachments — re-run cleanup on v3.5.2 if you relied on that path.
+- **Regression tests:** `TestEntityScanner_StampsRunIDOnRunBoundAttachments`,
+  `TestEntityScanner_WalksTestsForResultBoundAttachments`,
+  `TestEntityScanner_CollectRunIDsFromPlanEntries` lock both fixes.
+
+### Removed
+
+- **v3.5.1 release** is withdrawn from GitHub Releases after v3.5.2
+  binaries are published — the v3.5.1 entity scanner skipped
+  run/result attachments. Use v3.5.2.
+
+---
+
 ## [3.5.1] - 2026-05-05
 
 ### Fixed — emit cleanup deletion report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,16 @@ _No unreleased changes yet._
   attachments — re-run cleanup on v3.5.2 if you relied on that path.
 - **Regression tests:** `TestEntityScanner_StampsRunIDOnRunBoundAttachments`,
   `TestEntityScanner_WalksTestsForResultBoundAttachments`,
-  `TestEntityScanner_CollectRunIDsFromPlanEntries` lock both fixes.
+  `TestEntityScanner_CollectRunIDsFromPlanEntries`,
+  `TestEntityScanner_WalksPlanEntriesForEntryBoundAttachments` lock
+  every fix.
+- **Plan-entry attachments are now scanned.** The plan walk previously
+  only called `get_attachments_for_plan/{id}`, so attachments uploaded
+  via `add_attachment_to_plan_entry/{plan_id}/{entry_id}` were
+  unreachable for `--entity-type plan_entry`. The walk now expands
+  every plan via `GetPlan` and fetches
+  `get_attachments_for_plan_entry/{plan_id}/{entry_id}` per entry,
+  stamping `plan_id` + `entry_id` on each result.
 
 ### Changed — `attachments cleanup --entity-type` default is now ALL kinds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,22 @@ _No unreleased changes yet._
   `TestEntityScanner_WalksTestsForResultBoundAttachments`,
   `TestEntityScanner_CollectRunIDsFromPlanEntries` lock both fixes.
 
+### Changed — `attachments cleanup --entity-type` default is now ALL kinds
+
+- **Default scope is the full set** `case,run,plan,plan_entry,result,test`
+  (was `result` only). This matches the entity-scanner fix above so
+  invocations without `--entity-type` no longer silently skip run/case/
+  plan-bound attachments.
+- **Mandatory scope notice** is printed before scanning. When the
+  resolved scope covers ALL kinds the notice is rendered as a ⚠️
+  warning with a hint on how to narrow with `--entity-type`. Narrower
+  scopes get a one-line ℹ️ confirmation.
+- **Interactive prompt** now warns before asking and offers the
+  presets `all` / `case` / `run` / `plan,plan_entry` / `result,test` /
+  `custom` so users can correct the scope in one keystroke.
+- The pre-flight summary table and the final `Proceed with deletion?`
+  confirmation already exist and continue to gate destructive runs.
+
 ### Removed
 
 - **v3.5.1 release** is withdrawn from GitHub Releases after v3.5.2

--- a/CHANGELOG.ru.md
+++ b/CHANGELOG.ru.md
@@ -40,7 +40,15 @@ _Пока без изменений._
   очистку на v3.5.2, если использовали этот путь.
 - **Регрессионные тесты:** `TestEntityScanner_StampsRunIDOnRunBoundAttachments`,
   `TestEntityScanner_WalksTestsForResultBoundAttachments`,
-  `TestEntityScanner_CollectRunIDsFromPlanEntries` фиксируют оба фикса.
+  `TestEntityScanner_CollectRunIDsFromPlanEntries`,
+  `TestEntityScanner_WalksPlanEntriesForEntryBoundAttachments` фиксируют все правки.
+- **Вложения plan-entry теперь сканируются.** Walk по планам ранее
+  вызывал только `get_attachments_for_plan/{id}`, поэтому вложения,
+  загруженные через `add_attachment_to_plan_entry/{plan_id}/{entry_id}`,
+  были недостижимы для `--entity-type plan_entry`. Теперь walk
+  раскрывает каждый план через `GetPlan` и вызывает
+  `get_attachments_for_plan_entry/{plan_id}/{entry_id}` для каждой
+  записи, проставляя `plan_id` + `entry_id`.
 
 ### Changed — `attachments cleanup --entity-type` по умолчанию очищает ВСЕ типы
 

--- a/CHANGELOG.ru.md
+++ b/CHANGELOG.ru.md
@@ -15,6 +15,41 @@ _Пока без изменений._
 
 ---
 
+## [3.5.2] - 2026-05-05
+
+### Fixed — entity-сканер: полное покрытие run/result-вложений
+
+- **Run-bound вложения больше не теряются.** TestRail Server (особенно
+  self-hosted < 7.5) возвращает в `get_attachments_for_run/{id}`
+  поля `run_id`/`case_id`/`result_id` равными `null`. Прежний сканер
+  опирался на эти поля, в итоге `InferredEntityType()` возвращал пустую
+  строку и фильтр `--entity-type run` отбрасывал все run-bound
+  вложения. Теперь сканер штампует parent ID после каждого вызова.
+- **Result/test-bound вложения теперь сканируются.** Entity-сканер
+  ходил только по `cases → runs → plans`; result-bound вложения
+  достижимы только через `get_attachments_for_test/{test_id}` и
+  молча игнорировались. Добавлен walk по тестам: все runs (project +
+  plan entries) → tests → attachments. `--entity-type result|test`
+  теперь маршрутизируются в этот walk.
+- **Изменение маппинга:** `EntityScannerOptionsFromTypes` больше не
+  смешивает `result`/`test` с walk-ом по cases. Новый флаг
+  `EntityScannerOptions.WalkTests` управляет отдельным проходом.
+  Поведение по умолчанию (без `--entity-type`) обходит **все четыре**
+  типа (cases, runs, plans, tests). v3.5.1 затронут; запуски без
+  `--entity-type` могли пропустить run/result вложения — повторите
+  очистку на v3.5.2, если использовали этот путь.
+- **Регрессионные тесты:** `TestEntityScanner_StampsRunIDOnRunBoundAttachments`,
+  `TestEntityScanner_WalksTestsForResultBoundAttachments`,
+  `TestEntityScanner_CollectRunIDsFromPlanEntries` фиксируют оба фикса.
+
+### Removed
+
+- **Релиз v3.5.1** будет снят с GitHub Releases после публикации
+  бинарников v3.5.2 — entity-сканер v3.5.1 пропускал run/result
+  вложения. Используйте v3.5.2.
+
+---
+
 ## [3.5.1] - 2026-05-05
 
 ### Fixed — отчёт об удалении после очистки вложений

--- a/CHANGELOG.ru.md
+++ b/CHANGELOG.ru.md
@@ -42,6 +42,21 @@ _Пока без изменений._
   `TestEntityScanner_WalksTestsForResultBoundAttachments`,
   `TestEntityScanner_CollectRunIDsFromPlanEntries` фиксируют оба фикса.
 
+### Changed — `attachments cleanup --entity-type` по умолчанию очищает ВСЕ типы
+
+- **Дефолтный scope — полный набор** `case,run,plan,plan_entry,result,test`
+  (было только `result`). Это согласовано с фиксом entity-сканера:
+  запуски без `--entity-type` больше не пропускают run/case/plan-вложения.
+- **Обязательное уведомление о scope** печатается перед сканированием.
+  Если результирующий scope покрывает ВСЕ типы — это ⚠️-предупреждение
+  с подсказкой, как сузить через `--entity-type`. Для более узкого
+  scope печатается короткая ℹ️-плашка.
+- **Интерактивный режим** показывает предупреждение перед вопросом и
+  предлагает пресеты `all` / `case` / `run` / `plan,plan_entry` /
+  `result,test` / `custom`, чтобы скорректировать scope в один клик.
+- Сводная таблица перед удалением и финальный
+  `Proceed with deletion?` уже были и продолжают защищать запуск.
+
 ### Removed
 
 - **Релиз v3.5.1** будет снят с GitHub Releases после публикации

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.5.1-blue.svg" alt="Latest Release"/></a>
+  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.5.2-blue.svg" alt="Latest Release"/></a>
   <a href="go.mod"><img src="https://img.shields.io/badge/go-1.25-00ADD8.svg?logo=go" alt="Go"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/></a>
   <a href="docs/index.md"><img src="https://img.shields.io/badge/docs-EN%20%7C%20RU-purple.svg" alt="Docs"/></a>

--- a/README_ru.md
+++ b/README_ru.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.5.1-blue.svg" alt="Latest Release"/></a>
+  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.5.2-blue.svg" alt="Latest Release"/></a>
   <a href="go.mod"><img src="https://img.shields.io/badge/go-1.25-00ADD8.svg?logo=go" alt="Go"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/></a>
   <a href="docs/index.md"><img src="https://img.shields.io/badge/docs-EN%20%7C%20RU-purple.svg" alt="Docs"/></a>

--- a/cmd/attachments/cleanup.go
+++ b/cmd/attachments/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +44,10 @@ Workflow:
      ~/.gotr/snaps/cleanup-attachments/<id>/  (default: ON, retention 7 days).
   5. Delete in parallel via the TestRail API.
 
+WARNING: by default the cleanup targets ALL attachment kinds
+(case, run, plan, plan_entry, result, test). A scope notice is printed
+before scanning so you can abort and narrow with --entity-type.
+
 Rollback re-uploads each binary to its original parent. TestRail assigns
 new attachment IDs on re-upload — the rollback report records the
 old_id → new_id mapping. Attachments bound to entity_type=test cannot be
@@ -62,7 +67,8 @@ as Skipped.`,
 	cmd.Flags().Int64Slice("project", nil, "Project ID(s); repeat or comma-separate. Mutually exclusive with --all-projects")
 	cmd.Flags().Bool("all-projects", false, "Walk every visible project")
 	cmd.Flags().String("older-than", "", "Age cutoff (e.g. 7d, 3M, 1y). Required unless --dry-run on a small set")
-	cmd.Flags().StringSlice("entity-type", []string{"result"}, "Parent kinds: case,run,plan,plan_entry,result,test")
+	cmd.Flags().StringSlice("entity-type", append([]string(nil), validCleanupEntityTypes...),
+		"Parent kinds to clean (DEFAULT: ALL — case,run,plan,plan_entry,result,test). Narrow scope to avoid touching unrelated data.")
 	cmd.Flags().Bool("dry-run", false, "Preview only; no snapshot, no deletes")
 	cmd.Flags().Int("concurrency", 4, "Worker count for list and delete phases")
 	cmd.Flags().Int("limit", 0, "Hard cap on the number of attachments to delete (0 = no cap)")
@@ -113,6 +119,8 @@ func runCleanup(getClient GetClientFunc) func(*cobra.Command, []string) error {
 		if err := promptCleanupOptions(ctx, cmd, opts); err != nil {
 			return fmt.Errorf("interactive: %w", err)
 		}
+
+		printEntityScopeNotice(cmd, opts)
 
 		if !opts.AllProjects && len(opts.ProjectIDs) == 0 {
 			return fmt.Errorf("either --project or --all-projects is required")
@@ -288,6 +296,47 @@ func toEntityTypeSet(types []string) map[string]struct{} {
 		out[t] = struct{}{}
 	}
 	return out
+}
+
+// entityTypesCoversAll reports whether the provided slice covers every
+// supported parent kind (case, run, plan, plan_entry, result, test).
+// An empty slice also counts as "covers all" because downstream filters
+// treat nil EntityTypes as "allow any kind".
+func entityTypesCoversAll(types []string) bool {
+	if len(types) == 0 {
+		return true
+	}
+	seen := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		seen[strings.ToLower(strings.TrimSpace(t))] = struct{}{}
+	}
+	for _, want := range validCleanupEntityTypes {
+		if _, ok := seen[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// printEntityScopeNotice prints a one-time pre-scan notice describing
+// which attachment kinds the cleanup is about to touch. When the
+// resolved scope covers ALL kinds the notice is rendered as a WARNING
+// so the user can abort and rerun with a narrower --entity-type. When
+// the scope is narrower the notice is informational only.
+func printEntityScopeNotice(cmd *cobra.Command, opts *cleanupOptions) {
+	w := cmd.ErrOrStderr()
+	if entityTypesCoversAll(opts.EntityTypes) {
+		fmt.Fprintln(w, "⚠️  Cleanup scope: ALL attachment kinds (case, run, plan, plan_entry, result, test)")
+		fmt.Fprintln(w, "   This will scan and delete attachments attached to test cases, test runs,")
+		fmt.Fprintln(w, "   test plans / plan entries, individual test results, and tests.")
+		fmt.Fprintln(w, "   To narrow the scope use --entity-type, e.g.:")
+		fmt.Fprintln(w, "       gotr attachments cleanup --entity-type result")
+		fmt.Fprintln(w, "       gotr attachments cleanup --entity-type case,run")
+		return
+	}
+	scoped := append([]string(nil), opts.EntityTypes...)
+	sort.Strings(scoped)
+	fmt.Fprintf(w, "ℹ️  Cleanup scope: %s\n", strings.Join(scoped, ", "))
 }
 
 // parseHumanDuration accepts shorthand suffixes Go's time.ParseDuration

--- a/cmd/attachments/cleanup_interactive.go
+++ b/cmd/attachments/cleanup_interactive.go
@@ -54,15 +54,42 @@ func promptCleanupOptions(ctx context.Context, cmd *cobra.Command, opts *cleanup
 		}
 	}
 
-	// 2. Entity types — multi-select via comma-separated input with
-	//    inline help. Empty answer keeps the flag default.
+	// 2. Entity types — show a scope warning + preset picker so the
+	//    user can avoid the "DELETE EVERYTHING" default in one step.
 	if !flagExplicit(cmd, "entity-type") {
-		raw, err := p.Input(
-			"Parent kinds to clean (comma-separated: case,run,plan,plan_entry,result,test)",
-			strings.Join(opts.EntityTypes, ","),
+		out := cmd.ErrOrStderr()
+		fmt.Fprintln(out, "⚠️  By default cleanup targets ALL attachment kinds:")
+		fmt.Fprintln(out, "       case, run, plan, plan_entry, result, test")
+		fmt.Fprintln(out, "   Narrow the scope now to avoid touching unrelated data.")
+
+		const (
+			presetAll    = "all (case,run,plan,plan_entry,result,test)"
+			presetCase   = "case"
+			presetRun    = "run"
+			presetPlans  = "plan,plan_entry"
+			presetResult = "result,test"
+			presetCustom = "custom (comma-separated)"
 		)
+		_, choice, err := p.Select("Parent kinds to clean", []string{
+			presetAll, presetCase, presetRun, presetPlans, presetResult, presetCustom,
+		})
 		if err != nil {
 			return fmt.Errorf("entity types: %w", err)
+		}
+		var raw string
+		switch choice {
+		case presetAll:
+			raw = strings.Join(validCleanupEntityTypes, ",")
+		case presetCustom:
+			raw, err = p.Input(
+				"Parent kinds (comma-separated: case,run,plan,plan_entry,result,test)",
+				strings.Join(opts.EntityTypes, ","),
+			)
+			if err != nil {
+				return fmt.Errorf("entity types: %w", err)
+			}
+		default:
+			raw = choice
 		}
 		types, err := parseEntityTypeList(raw)
 		if err != nil {
@@ -191,7 +218,7 @@ func parseInt64List(raw string) ([]int64, error) {
 
 func parseEntityTypeList(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {
-		return []string{"result"}, nil
+		return append([]string(nil), validCleanupEntityTypes...), nil
 	}
 	parts := strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' })
 	out := make([]string, 0, len(parts))

--- a/cmd/attachments/cleanup_interactive_test.go
+++ b/cmd/attachments/cleanup_interactive_test.go
@@ -34,12 +34,14 @@ func TestPromptCleanupOptions_NoOpWithoutPrompter(t *testing.T) {
 
 func TestPromptCleanupOptions_AllProjectsHappyPath(t *testing.T) {
 	mock := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 0, Value: "All visible projects"}).
+		WithSelectResponses(
+			interactive.SelectResponse{Index: 0, Value: "All visible projects"},
+			interactive.SelectResponse{Index: 3, Value: "result"}, // entity-type preset
+		).
 		WithInputResponses(
-			"result",     // entity types
-			"3M",         // older-than
-			"6",          // concurrency
-			"7d",         // snapshot retention
+			"3M", // older-than
+			"6",  // concurrency
+			"7d", // snapshot retention
 		).
 		WithConfirmResponses(
 			true,  // take snapshot
@@ -78,10 +80,13 @@ func TestPromptCleanupOptions_AllProjectsHappyPath(t *testing.T) {
 
 func TestPromptCleanupOptions_SpecificProjects(t *testing.T) {
 	mock := interactive.NewMockPrompter().
-		WithSelectResponses(interactive.SelectResponse{Index: 1, Value: "Specific project IDs"}).
+		WithSelectResponses(
+			interactive.SelectResponse{Index: 1, Value: "Specific project IDs"},
+			interactive.SelectResponse{Index: 5, Value: "custom (comma-separated)"},
+		).
 		WithInputResponses(
-			"42, 7,  9", // project IDs
-			"result,run", // entity types
+			"42, 7,  9",  // project IDs
+			"result,run", // entity types (custom)
 			"30d",        // older-than
 			"",           // concurrency (keep default)
 			"7d",         // retention
@@ -120,8 +125,8 @@ func TestParseEntityTypeList_Validation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("empty input err: %v", err)
 	}
-	if len(got) != 1 || got[0] != "result" {
-		t.Fatalf("empty input default: %v", got)
+	if len(got) != len(validCleanupEntityTypes) {
+		t.Fatalf("empty input default should cover all kinds, got %v", got)
 	}
 }
 

--- a/cmd/attachments/cleanup_scope_test.go
+++ b/cmd/attachments/cleanup_scope_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Igor "Breezefall" Vasilenko
+// See LICENSE.md for details
+
+package attachments
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestEntityTypesCoversAll(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want bool
+	}{
+		{"nil treated as ALL", nil, true},
+		{"empty treated as ALL", []string{}, true},
+		{"all kinds explicit", append([]string(nil), validCleanupEntityTypes...), true},
+		{"all kinds shuffled+upper", []string{"TEST", "result", "Plan_Entry", "plan", "run", "case"}, true},
+		{"missing one", []string{"case", "run", "plan", "plan_entry", "result"}, false},
+		{"single kind", []string{"result"}, false},
+		{"two kinds", []string{"case", "run"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := entityTypesCoversAll(c.in); got != c.want {
+				t.Fatalf("entityTypesCoversAll(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPrintEntityScopeNotice_AllKindsWarning(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetErr(&buf)
+	printEntityScopeNotice(cmd, &cleanupOptions{
+		EntityTypes: append([]string(nil), validCleanupEntityTypes...),
+	})
+	out := buf.String()
+	if !strings.Contains(out, "⚠️") {
+		t.Fatalf("expected warning glyph in:\n%s", out)
+	}
+	if !strings.Contains(out, "ALL attachment kinds") {
+		t.Fatalf("expected ALL-scope wording in:\n%s", out)
+	}
+	if !strings.Contains(out, "--entity-type") {
+		t.Fatalf("expected hint about --entity-type in:\n%s", out)
+	}
+}
+
+func TestPrintEntityScopeNotice_NarrowScopeInfo(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetErr(&buf)
+	printEntityScopeNotice(cmd, &cleanupOptions{
+		EntityTypes: []string{"result", "case"},
+	})
+	out := buf.String()
+	if strings.Contains(out, "⚠️") {
+		t.Fatalf("narrow scope must not warn:\n%s", out)
+	}
+	if !strings.Contains(out, "ℹ️") {
+		t.Fatalf("expected info glyph:\n%s", out)
+	}
+	if !strings.Contains(out, "case, result") {
+		t.Fatalf("expected sorted scope list 'case, result' in:\n%s", out)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// Version is populated at build time via -ldflags.
-	Version = "3.5.1" // default value for local development
+	Version = "3.5.2" // default value for local development
 	Commit  = "unknown"
 	Date    = "unknown"
 	userHomeDir = os.UserHomeDir

--- a/internal/cleanup/scanner.go
+++ b/internal/cleanup/scanner.go
@@ -65,7 +65,10 @@ type EntityAttachmentsAPI interface {
 	GetRuns(ctx context.Context, projectID int64) (data.GetRunsResponse, error)
 	GetAttachmentsForRun(ctx context.Context, runID int64) (data.GetAttachmentsResponse, error)
 	GetPlans(ctx context.Context, projectID int64) (data.GetPlansResponse, error)
+	GetPlan(ctx context.Context, planID int64) (*data.Plan, error)
 	GetAttachmentsForPlan(ctx context.Context, planID int64) (data.GetAttachmentsResponse, error)
+	GetTests(ctx context.Context, runID int64, filters map[string]string) ([]data.Test, error)
+	GetAttachmentsForTest(ctx context.Context, testID int64) (data.GetAttachmentsResponse, error)
 }
 
 // ScannerAPI is the union required by ResolveScanner: both endpoints
@@ -99,24 +102,26 @@ func (s *projectScanner) Scan(ctx context.Context, projectID int64) ([]data.Atta
 	return atts, nil
 }
 
-// entityScanner walks suites → cases (and optionally runs/plans),
+// entityScanner walks suites → cases (and optionally runs/plans/tests),
 // fetching attachments per entity in parallel and deduplicating by ID.
 type entityScanner struct {
 	api         EntityAttachmentsAPI
 	walkCases   bool
 	walkRuns    bool
 	walkPlans   bool
+	walkTests   bool
 	concurrency int
 }
 
 // EntityScannerOptions narrows the entity walk. When all booleans are
 // false the scanner walks every supported entity kind (cases, runs,
-// plans) — matching the default "scan everything" behavior callers
-// expect when --entity-type is unset.
+// plans, tests) — matching the default "scan everything" behavior
+// callers expect when --entity-type is unset.
 type EntityScannerOptions struct {
 	WalkCases   bool
 	WalkRuns    bool
 	WalkPlans   bool
+	WalkTests   bool
 	Concurrency int
 }
 
@@ -127,10 +132,11 @@ type EntityScannerOptions struct {
 func NewEntityScanner(api EntityAttachmentsAPI, opts EntityScannerOptions) AttachmentScanner {
 	// If no walk is requested, fall back to walking every entity kind:
 	// the AttachmentFilter still narrows the result downstream.
-	if !opts.WalkCases && !opts.WalkRuns && !opts.WalkPlans {
+	if !opts.WalkCases && !opts.WalkRuns && !opts.WalkPlans && !opts.WalkTests {
 		opts.WalkCases = true
 		opts.WalkRuns = true
 		opts.WalkPlans = true
+		opts.WalkTests = true
 	}
 	if opts.Concurrency <= 0 {
 		opts.Concurrency = 4
@@ -140,24 +146,28 @@ func NewEntityScanner(api EntityAttachmentsAPI, opts EntityScannerOptions) Attac
 		walkCases:   opts.WalkCases,
 		walkRuns:    opts.WalkRuns,
 		walkPlans:   opts.WalkPlans,
+		walkTests:   opts.WalkTests,
 		concurrency: opts.Concurrency,
 	}
 }
 
 // EntityScannerOptionsFromTypes translates AttachmentFilter.EntityTypes
-// into the entity-walk plan. "case", "result" and "test" all imply the
-// case walk because TestRail attaches results/tests under a case.
+// into the entity-walk plan. "case" implies the case walk;
+// "result"/"test" imply the tests walk (TestRail exposes result-bound
+// attachments via get_attachments_for_test, not under the parent case).
 // "plan_entry" implies the plan walk because plan entries are reached
 // through their parent plan.
 func EntityScannerOptionsFromTypes(types map[string]struct{}, concurrency int) EntityScannerOptions {
 	if len(types) == 0 {
-		return EntityScannerOptions{WalkCases: true, WalkRuns: true, WalkPlans: true, Concurrency: concurrency}
+		return EntityScannerOptions{WalkCases: true, WalkRuns: true, WalkPlans: true, WalkTests: true, Concurrency: concurrency}
 	}
 	opts := EntityScannerOptions{Concurrency: concurrency}
 	for t := range types {
 		switch t {
-		case "case", "result", "test":
+		case "case":
 			opts.WalkCases = true
+		case "result", "test":
+			opts.WalkTests = true
 		case "run":
 			opts.WalkRuns = true
 		case "plan", "plan_entry":
@@ -168,6 +178,53 @@ func EntityScannerOptionsFromTypes(types map[string]struct{}, concurrency int) E
 }
 
 func (s *entityScanner) Name() string { return "entities" }
+
+// stampParent fills in the parent-id field on attachments that the
+// server returned without it. Some TestRail Server builds (notably the
+// self-hosted < 7.5 fleet) omit run_id/plan_id/case_id in the
+// per-entity attachment listings, breaking downstream
+// InferredEntityType()-based filtering. We compensate by stamping the
+// known parent id from the walk context. EntityType is left untouched
+// when the server already populated it (TestRail >= 7.1 cloud format).
+func stampParent(atts []data.Attachment, kind string, parentID int64, entryID string) {
+	for i := range atts {
+		switch kind {
+		case "case":
+			if atts[i].CaseID == 0 {
+				atts[i].CaseID = parentID
+			}
+		case "run":
+			if atts[i].RunID == 0 {
+				atts[i].RunID = parentID
+			}
+		case "plan":
+			if atts[i].PlanID == 0 {
+				atts[i].PlanID = parentID
+			}
+		case "plan_entry":
+			if atts[i].PlanID == 0 {
+				atts[i].PlanID = parentID
+			}
+			if atts[i].EntryID == "" {
+				atts[i].EntryID = entryID
+			}
+		case "test":
+			if atts[i].TestID == 0 {
+				atts[i].TestID = parentID
+			}
+		}
+		if atts[i].EntityType == "" {
+			// Prefer "result" when the payload has a result_id (TestRail
+			// returns these under get_attachments_for_test) so the
+			// AttachmentFilter "result" type matches.
+			if atts[i].ResultID != 0 {
+				atts[i].EntityType = "result"
+			} else {
+				atts[i].EntityType = kind
+			}
+		}
+	}
+}
 
 //nolint:gocyclo // Sequential per-kind walks (cases / runs / plans) are clearer kept inline.
 func (s *entityScanner) Scan(ctx context.Context, projectID int64) ([]data.Attachment, error) {
@@ -199,6 +256,7 @@ func (s *entityScanner) Scan(ctx context.Context, projectID int64) ([]data.Attac
 				if err != nil {
 					return nil, fmt.Errorf("get_attachments_for_case %d: %w", c.ID, err)
 				}
+				stampParent(atts, "case", c.ID, "")
 				return atts, nil
 			})
 			for _, r := range res {
@@ -220,6 +278,7 @@ func (s *entityScanner) Scan(ctx context.Context, projectID int64) ([]data.Attac
 			if err != nil {
 				return nil, fmt.Errorf("get_attachments_for_run %d: %w", r.ID, err)
 			}
+			stampParent(atts, "run", r.ID, "")
 			return atts, nil
 		})
 		for _, r := range res {
@@ -240,6 +299,7 @@ func (s *entityScanner) Scan(ctx context.Context, projectID int64) ([]data.Attac
 			if err != nil {
 				return nil, fmt.Errorf("get_attachments_for_plan %d: %w", p.ID, err)
 			}
+			stampParent(atts, "plan", p.ID, "")
 			return atts, nil
 		})
 		for _, r := range res {
@@ -250,7 +310,98 @@ func (s *entityScanner) Scan(ctx context.Context, projectID int64) ([]data.Attac
 		}
 	}
 
+	if s.walkTests {
+		runIDs, err := s.collectRunIDs(ctx, projectID)
+		if err != nil {
+			return nil, err
+		}
+		// Enumerate tests per run, then attachments per test. Two
+		// levels of parallelism; cap inner to avoid burst on large
+		// runs by reusing the same concurrency budget.
+		testsPerRun, _ := concurrent.ParallelMap(ctx, runIDs, s.concurrency, func(runID int64, _ int) ([]data.Test, error) {
+			tests, err := s.api.GetTests(ctx, runID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("get_tests run=%d: %w", runID, err)
+			}
+			return tests, nil
+		})
+		var allTests []data.Test
+		for _, r := range testsPerRun {
+			if r.Error != nil {
+				return nil, r.Error
+			}
+			allTests = append(allTests, r.Data...)
+		}
+		attsPerTest, _ := concurrent.ParallelMap(ctx, allTests, s.concurrency, func(t data.Test, _ int) ([]data.Attachment, error) {
+			atts, err := s.api.GetAttachmentsForTest(ctx, t.ID)
+			if err != nil {
+				return nil, fmt.Errorf("get_attachments_for_test %d: %w", t.ID, err)
+			}
+			stampParent(atts, "test", t.ID, "")
+			return atts, nil
+		})
+		for _, r := range attsPerTest {
+			if r.Error != nil {
+				return nil, r.Error
+			}
+			collect(r.Data)
+		}
+	}
+
 	return out, nil
+}
+
+// collectRunIDs returns the union of project-level run IDs (GetRuns)
+// and plan-bound run IDs (GetPlans → GetPlan → Entries[].Runs[]). The
+// tests walk uses this set to enumerate every test reachable in the
+// project. Duplicates are removed.
+func (s *entityScanner) collectRunIDs(ctx context.Context, projectID int64) ([]int64, error) {
+	seen := make(map[int64]struct{})
+	var ids []int64
+	add := func(id int64) {
+		if id == 0 {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	runs, err := s.api.GetRuns(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("get_runs %d: %w", projectID, err)
+	}
+	for _, r := range runs {
+		add(r.ID)
+	}
+
+	plans, err := s.api.GetPlans(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("get_plans %d: %w", projectID, err)
+	}
+	planDetails, _ := concurrent.ParallelMap(ctx, plans, s.concurrency, func(p data.Plan, _ int) (*data.Plan, error) {
+		full, err := s.api.GetPlan(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("get_plan %d: %w", p.ID, err)
+		}
+		return full, nil
+	})
+	for _, r := range planDetails {
+		if r.Error != nil {
+			return nil, r.Error
+		}
+		if r.Data == nil {
+			continue
+		}
+		for _, e := range r.Data.Entries {
+			for _, run := range e.Runs {
+				add(run.ID)
+			}
+		}
+	}
+	return ids, nil
 }
 
 // ResolveScanner picks the scanner implementation honoring strategy.

--- a/internal/cleanup/scanner.go
+++ b/internal/cleanup/scanner.go
@@ -67,6 +67,7 @@ type EntityAttachmentsAPI interface {
 	GetPlans(ctx context.Context, projectID int64) (data.GetPlansResponse, error)
 	GetPlan(ctx context.Context, planID int64) (*data.Plan, error)
 	GetAttachmentsForPlan(ctx context.Context, planID int64) (data.GetAttachmentsResponse, error)
+	GetAttachmentsForPlanEntry(ctx context.Context, planID int64, entryID string) (data.GetAttachmentsResponse, error)
 	GetTests(ctx context.Context, runID int64, filters map[string]string) ([]data.Test, error)
 	GetAttachmentsForTest(ctx context.Context, testID int64) (data.GetAttachmentsResponse, error)
 }
@@ -295,12 +296,34 @@ func (s *entityScanner) Scan(ctx context.Context, projectID int64) ([]data.Attac
 			return nil, fmt.Errorf("get_plans %d: %w", projectID, err)
 		}
 		res, _ := concurrent.ParallelMap(ctx, plans, s.concurrency, func(p data.Plan, _ int) ([]data.Attachment, error) {
+			var acc []data.Attachment
 			atts, err := s.api.GetAttachmentsForPlan(ctx, p.ID)
 			if err != nil {
 				return nil, fmt.Errorf("get_attachments_for_plan %d: %w", p.ID, err)
 			}
 			stampParent(atts, "plan", p.ID, "")
-			return atts, nil
+			acc = append(acc, atts...)
+
+			// Expand plan entries — TestRail exposes entry-bound
+			// attachments only via get_attachments_for_plan_entry/{plan}/{entry}.
+			full, ferr := s.api.GetPlan(ctx, p.ID)
+			if ferr != nil {
+				return nil, fmt.Errorf("get_plan %d: %w", p.ID, ferr)
+			}
+			if full != nil {
+				for _, e := range full.Entries {
+					if e.ID == "" {
+						continue
+					}
+					eAtts, eerr := s.api.GetAttachmentsForPlanEntry(ctx, p.ID, e.ID)
+					if eerr != nil {
+						return nil, fmt.Errorf("get_attachments_for_plan_entry %d/%s: %w", p.ID, e.ID, eerr)
+					}
+					stampParent(eAtts, "plan_entry", p.ID, e.ID)
+					acc = append(acc, eAtts...)
+				}
+			}
+			return acc, nil
 		})
 		for _, r := range res {
 			if r.Error != nil {

--- a/internal/cleanup/scanner_test.go
+++ b/internal/cleanup/scanner_test.go
@@ -20,7 +20,10 @@ type fakeScannerAPI struct {
 	getRuns                  func(int64) (data.GetRunsResponse, error)
 	getAttachmentsForRun     func(int64) (data.GetAttachmentsResponse, error)
 	getPlans                 func(int64) (data.GetPlansResponse, error)
+	getPlan                  func(int64) (*data.Plan, error)
 	getAttachmentsForPlan    func(int64) (data.GetAttachmentsResponse, error)
+	getTests                 func(runID int64) ([]data.Test, error)
+	getAttachmentsForTest    func(int64) (data.GetAttachmentsResponse, error)
 }
 
 func (f *fakeScannerAPI) GetAttachmentsForProject(_ context.Context, id int64) (data.GetAttachmentsResponse, error) {
@@ -68,6 +71,24 @@ func (f *fakeScannerAPI) GetPlans(_ context.Context, id int64) (data.GetPlansRes
 func (f *fakeScannerAPI) GetAttachmentsForPlan(_ context.Context, id int64) (data.GetAttachmentsResponse, error) {
 	if f.getAttachmentsForPlan != nil {
 		return f.getAttachmentsForPlan(id)
+	}
+	return nil, nil
+}
+func (f *fakeScannerAPI) GetPlan(_ context.Context, id int64) (*data.Plan, error) {
+	if f.getPlan != nil {
+		return f.getPlan(id)
+	}
+	return &data.Plan{ID: id}, nil
+}
+func (f *fakeScannerAPI) GetTests(_ context.Context, runID int64, _ map[string]string) ([]data.Test, error) {
+	if f.getTests != nil {
+		return f.getTests(runID)
+	}
+	return nil, nil
+}
+func (f *fakeScannerAPI) GetAttachmentsForTest(_ context.Context, id int64) (data.GetAttachmentsResponse, error) {
+	if f.getAttachmentsForTest != nil {
+		return f.getAttachmentsForTest(id)
 	}
 	return nil, nil
 }
@@ -224,22 +245,129 @@ func TestEntityScannerOptionsFromTypes(t *testing.T) {
 	cases := []struct {
 		name              string
 		types             map[string]struct{}
-		wantCases, wantRuns, wantPlans bool
+		wantCases, wantRuns, wantPlans, wantTests bool
 	}{
-		{"empty -> all", nil, true, true, true},
-		{"case", map[string]struct{}{"case": {}}, true, false, false},
-		{"result implies case", map[string]struct{}{"result": {}}, true, false, false},
-		{"test implies case", map[string]struct{}{"test": {}}, true, false, false},
-		{"run only", map[string]struct{}{"run": {}}, false, true, false},
-		{"plan_entry implies plan", map[string]struct{}{"plan_entry": {}}, false, false, true},
-		{"mixed", map[string]struct{}{"case": {}, "run": {}}, true, true, false},
+		{"empty -> all", nil, true, true, true, true},
+		{"case", map[string]struct{}{"case": {}}, true, false, false, false},
+		{"result implies tests", map[string]struct{}{"result": {}}, false, false, false, true},
+		{"test implies tests", map[string]struct{}{"test": {}}, false, false, false, true},
+		{"run only", map[string]struct{}{"run": {}}, false, true, false, false},
+		{"plan_entry implies plan", map[string]struct{}{"plan_entry": {}}, false, false, true, false},
+		{"mixed", map[string]struct{}{"case": {}, "run": {}, "result": {}}, true, true, false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := EntityScannerOptionsFromTypes(tc.types, 4)
-			if got.WalkCases != tc.wantCases || got.WalkRuns != tc.wantRuns || got.WalkPlans != tc.wantPlans {
-				t.Fatalf("got %+v, want cases=%v runs=%v plans=%v", got, tc.wantCases, tc.wantRuns, tc.wantPlans)
+			if got.WalkCases != tc.wantCases || got.WalkRuns != tc.wantRuns || got.WalkPlans != tc.wantPlans || got.WalkTests != tc.wantTests {
+				t.Fatalf("got %+v, want cases=%v runs=%v plans=%v tests=%v", got, tc.wantCases, tc.wantRuns, tc.wantPlans, tc.wantTests)
 			}
 		})
+	}
+}
+
+// TestEntityScanner_StampsRunIDOnRunBoundAttachments locks regression
+// for v3.5.1 bug where TestRail Server omitted run_id in
+// get_attachments_for_run responses, causing InferredEntityType() to
+// return "" and the AttachmentFilter "run" type to drop the item.
+func TestEntityScanner_StampsRunIDOnRunBoundAttachments(t *testing.T) {
+	api := &fakeScannerAPI{
+		getRuns: func(int64) (data.GetRunsResponse, error) {
+			return data.GetRunsResponse{{ID: 30798}}, nil
+		},
+		getAttachmentsForRun: func(runID int64) (data.GetAttachmentsResponse, error) {
+			// Server omits run_id, case_id, result_id (real TestRail
+			// Server <7.5 payload). Without the stamp the filter would
+			// drop this attachment.
+			return data.GetAttachmentsResponse{{ID: 3166974, Size: 20}}, nil
+		},
+	}
+	sc := NewEntityScanner(api, EntityScannerOptions{WalkRuns: true})
+	got, err := sc.Scan(context.Background(), 49)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d attachments, want 1", len(got))
+	}
+	if got[0].RunID != 30798 {
+		t.Fatalf("RunID = %d, want 30798 (stamp missing)", got[0].RunID)
+	}
+	if got[0].InferredEntityType() != "run" {
+		t.Fatalf("InferredEntityType() = %q, want run", got[0].InferredEntityType())
+	}
+}
+
+// TestEntityScanner_WalksTestsForResultBoundAttachments locks
+// regression for v3.5.1 bug where result/test-bound attachments were
+// only reachable via get_attachments_for_test but the entity scanner
+// walked only cases/runs/plans, missing them entirely.
+func TestEntityScanner_WalksTestsForResultBoundAttachments(t *testing.T) {
+	api := &fakeScannerAPI{
+		getRuns: func(int64) (data.GetRunsResponse, error) {
+			return data.GetRunsResponse{{ID: 30798}}, nil
+		},
+		getPlans: func(int64) (data.GetPlansResponse, error) { return nil, nil },
+		getTests: func(runID int64) ([]data.Test, error) {
+			if runID != 30798 {
+				return nil, nil
+			}
+			return []data.Test{{ID: 22979295}}, nil
+		},
+		getAttachmentsForTest: func(testID int64) (data.GetAttachmentsResponse, error) {
+			if testID != 22979295 {
+				return nil, nil
+			}
+			return data.GetAttachmentsResponse{{ID: 3166973, Size: 10, ResultID: 7531573, CaseID: 4404075}}, nil
+		},
+	}
+	sc := NewEntityScanner(api, EntityScannerOptions{WalkTests: true})
+	got, err := sc.Scan(context.Background(), 49)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d attachments, want 1", len(got))
+	}
+	if got[0].TestID != 22979295 {
+		t.Fatalf("TestID = %d, want 22979295", got[0].TestID)
+	}
+	if got[0].InferredEntityType() != "result" {
+		t.Fatalf("InferredEntityType() = %q, want result", got[0].InferredEntityType())
+	}
+}
+
+// TestEntityScanner_CollectRunIDsFromPlanEntries verifies plan-bound
+// runs (Entries[].Runs[]) are reachable for the tests walk.
+func TestEntityScanner_CollectRunIDsFromPlanEntries(t *testing.T) {
+	api := &fakeScannerAPI{
+		getRuns: func(int64) (data.GetRunsResponse, error) {
+			return data.GetRunsResponse{{ID: 1}}, nil
+		},
+		getPlans: func(int64) (data.GetPlansResponse, error) {
+			return data.GetPlansResponse{{ID: 100}}, nil
+		},
+		getPlan: func(planID int64) (*data.Plan, error) {
+			return &data.Plan{ID: planID, Entries: []data.PlanEntry{{Runs: []data.Run{{ID: 2}, {ID: 3}}}}}, nil
+		},
+		getTests: func(runID int64) ([]data.Test, error) {
+			return []data.Test{{ID: runID * 10}}, nil
+		},
+		getAttachmentsForTest: func(testID int64) (data.GetAttachmentsResponse, error) {
+			return data.GetAttachmentsResponse{{ID: testID, Size: 1, ResultID: testID}}, nil
+		},
+	}
+	sc := NewEntityScanner(api, EntityScannerOptions{WalkTests: true, Concurrency: 2})
+	got, err := sc.Scan(context.Background(), 49)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ids := make(map[int64]bool)
+	for _, a := range got {
+		ids[a.ID] = true
+	}
+	for _, want := range []int64{10, 20, 30} {
+		if !ids[want] {
+			t.Fatalf("missing attachment from test %d (ids=%v)", want, ids)
+		}
 	}
 }

--- a/internal/cleanup/scanner_test.go
+++ b/internal/cleanup/scanner_test.go
@@ -19,11 +19,12 @@ type fakeScannerAPI struct {
 	getAttachmentsForCase    func(int64) (data.GetAttachmentsResponse, error)
 	getRuns                  func(int64) (data.GetRunsResponse, error)
 	getAttachmentsForRun     func(int64) (data.GetAttachmentsResponse, error)
-	getPlans                 func(int64) (data.GetPlansResponse, error)
-	getPlan                  func(int64) (*data.Plan, error)
-	getAttachmentsForPlan    func(int64) (data.GetAttachmentsResponse, error)
-	getTests                 func(runID int64) ([]data.Test, error)
-	getAttachmentsForTest    func(int64) (data.GetAttachmentsResponse, error)
+	getPlans                   func(int64) (data.GetPlansResponse, error)
+	getPlan                    func(int64) (*data.Plan, error)
+	getAttachmentsForPlan      func(int64) (data.GetAttachmentsResponse, error)
+	getAttachmentsForPlanEntry func(planID int64, entryID string) (data.GetAttachmentsResponse, error)
+	getTests                   func(runID int64) ([]data.Test, error)
+	getAttachmentsForTest      func(int64) (data.GetAttachmentsResponse, error)
 }
 
 func (f *fakeScannerAPI) GetAttachmentsForProject(_ context.Context, id int64) (data.GetAttachmentsResponse, error) {
@@ -71,6 +72,12 @@ func (f *fakeScannerAPI) GetPlans(_ context.Context, id int64) (data.GetPlansRes
 func (f *fakeScannerAPI) GetAttachmentsForPlan(_ context.Context, id int64) (data.GetAttachmentsResponse, error) {
 	if f.getAttachmentsForPlan != nil {
 		return f.getAttachmentsForPlan(id)
+	}
+	return nil, nil
+}
+func (f *fakeScannerAPI) GetAttachmentsForPlanEntry(_ context.Context, planID int64, entryID string) (data.GetAttachmentsResponse, error) {
+	if f.getAttachmentsForPlanEntry != nil {
+		return f.getAttachmentsForPlanEntry(planID, entryID)
 	}
 	return nil, nil
 }
@@ -368,6 +375,71 @@ func TestEntityScanner_CollectRunIDsFromPlanEntries(t *testing.T) {
 	for _, want := range []int64{10, 20, 30} {
 		if !ids[want] {
 			t.Fatalf("missing attachment from test %d (ids=%v)", want, ids)
+		}
+	}
+}
+
+// TestEntityScanner_WalksPlanEntriesForEntryBoundAttachments locks the
+// fix for Copilot review on PR #70: --entity-type plan_entry (which
+// maps to WalkPlans) must enumerate plan entries via
+// get_attachments_for_plan_entry, not just get_attachments_for_plan.
+func TestEntityScanner_WalksPlanEntriesForEntryBoundAttachments(t *testing.T) {
+	planAttCalled := false
+	entryCalls := map[string]bool{}
+	api := &fakeScannerAPI{
+		getPlans: func(int64) (data.GetPlansResponse, error) {
+			return data.GetPlansResponse{{ID: 500}}, nil
+		},
+		getPlan: func(planID int64) (*data.Plan, error) {
+			return &data.Plan{ID: planID, Entries: []data.PlanEntry{
+				{ID: "e1"},
+				{ID: "e2"},
+				{ID: ""}, // must be skipped
+			}}, nil
+		},
+		getAttachmentsForPlan: func(planID int64) (data.GetAttachmentsResponse, error) {
+			planAttCalled = true
+			return data.GetAttachmentsResponse{{ID: 9000, Size: 1}}, nil
+		},
+		getAttachmentsForPlanEntry: func(planID int64, entryID string) (data.GetAttachmentsResponse, error) {
+			entryCalls[entryID] = true
+			switch entryID {
+			case "e1":
+				return data.GetAttachmentsResponse{{ID: 9001, Size: 1}}, nil
+			case "e2":
+				return data.GetAttachmentsResponse{{ID: 9002, Size: 1}}, nil
+			}
+			return nil, nil
+		},
+	}
+	sc := NewEntityScanner(api, EntityScannerOptions{WalkPlans: true, Concurrency: 1})
+	got, err := sc.Scan(context.Background(), 49)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !planAttCalled {
+		t.Fatalf("get_attachments_for_plan must still be called")
+	}
+	if !entryCalls["e1"] || !entryCalls["e2"] {
+		t.Fatalf("get_attachments_for_plan_entry not called for both entries: %v", entryCalls)
+	}
+	if entryCalls[""] {
+		t.Fatalf("blank entry id must be skipped")
+	}
+	want := map[int64]bool{9000: true, 9001: true, 9002: true}
+	for _, a := range got {
+		delete(want, a.ID)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing plan/entry attachments: %v", want)
+	}
+	// Stamping: entry-bound attachments must carry plan_id + entry_id.
+	for _, a := range got {
+		if a.ID == 9001 && (a.PlanID != 500 || a.EntryID != "e1") {
+			t.Fatalf("entry-bound 9001 not stamped: %+v", a)
+		}
+		if a.ID == 9002 && (a.PlanID != 500 || a.EntryID != "e2") {
+			t.Fatalf("entry-bound 9002 not stamped: %+v", a)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Two regressions in the v3.5.1 entity scanner caused TestRail Server attachments to be silently skipped during `gotr attachments cleanup`. Both are fixed and locked with regression tests; verified live on TestRail Server (project 49).

## Bugs fixed

### Bug A — server-omitted parent IDs dropped via filter
TestRail Server (notably self-hosted < 7.5) returns `get_attachments_for_run/{id}` payloads with `run_id`, `case_id`, `result_id` all `null`. The previous scanner relied on those fields, so `Attachment.InferredEntityType()` returned `""` and `AttachmentFilter` for `--entity-type run` filtered every run-bound attachment out.

**Fix:** new `stampParent` helper writes the known parent id onto each attachment after every per-entity fetch (case / run / plan / test). `EntityType` is also populated when missing.

### Bug B — result/test-bound attachments unreachable
The entity scanner walked only `cases → runs → plans`; result-bound files are reachable solely through `get_attachments_for_test/{test_id}` and were silently skipped. `EntityScannerOptionsFromTypes` mapped `"result"`/`"test"` to `WalkCases`, which doesn't list test attachments.

**Fix:** new `EntityScannerOptions.WalkTests` flag drives a dedicated walk: project runs ∪ plan-entry runs → tests → attachments. Mapping updated:

| `--entity-type` | walk |
|---|---|
| `case` | WalkCases |
| `run` | WalkRuns |
| `plan` / `plan_entry` | WalkPlans |
| `result` / `test` | **WalkTests** *(new)* |

Default (no `--entity-type`) walks **all four** kinds.

## Live verification on TestRail project 49

Before (v3.5.1): `cleanup --entity-type case,run,result --older-than 2m` → **2 of 6** attachments selected.
After (v3.5.2): same command → **6 of 6** (336 B). Per-type sanity:

| `--entity-type` | count | size |
|---|---|---|
| `case` | 2 | 276 B |
| `run` | 2 | 40 B |
| `result` | 2 | 20 B |
| combined | 6 | 336 B |

## Regression tests

- `TestEntityScanner_StampsRunIDOnRunBoundAttachments`
- `TestEntityScanner_WalksTestsForResultBoundAttachments`
- `TestEntityScanner_CollectRunIDsFromPlanEntries`

## Release plan

- Bumps `cmd/root.go` 3.5.1 → 3.5.2; CHANGELOG entries (en + ru).
- Tag `v3.5.2` after merge → CI publishes binaries.
- After v3.5.2 binaries are available, **withdraw the v3.5.1 GitHub Release** — the v3.5.1 entity scanner skipped run/result attachments and should not be advertised.