### PR TITLE
docs: sync v3.5.2 cleanup defaults

### DIFF
--- a/docs/en/guides/commands/attachments.md
+++ b/docs/en/guides/commands/attachments.md
@@ -154,7 +154,7 @@ gotr attachments cleanup --project 7,9 --older-than 30d --concurrency 8 --no-sna
 | --- | --- |
 | `--project <ids>` / `--all-projects` | Required scope selector (mutually exclusive). |
 | `--older-than <dur>` | Cutoff (e.g. `7d`, `3M`, `1y`, `720h`). Required unless `--dry-run`. |
-| `--entity-type` | Filter by parent kind: `case`, `run`, `plan`, `plan_entry`, `result`, `test` (default `result`). |
+| `--entity-type` | Filter by parent kind: `case`, `run`, `plan`, `plan_entry`, `result`, `test`. **Default since v3.5.2: all six kinds.** When the resolved scope covers ALL kinds, the command prints a ⚠️ pre-scan warning to stderr; narrow scopes get a one-line `ℹ️` confirmation. Pass an explicit list (e.g. `--entity-type result`) to limit the walk. |
 | `--dry-run` | Preview only; no snapshot, no deletes. |
 | `--no-snapshot` | Skip the safety-net snapshot. |
 | `--snapshot-retention <dur>` | Override snapshot TTL (default `7d`; honored by `gotr snap gc`). |
@@ -172,7 +172,7 @@ The bulk endpoint `get_attachments_for_project` was added in **TestRail 7.5**. O
 | Strategy | How attachments are listed | Works on |
 | --- | --- | --- |
 | `project` | Single bulk call to `get_attachments_for_project`. | TestRail 7.5+ / Cloud |
-| `entities` | Walk `get_suites → get_cases → get_attachments_for_case` (and optionally `get_runs` / `get_plans` based on `--entity-type`). Results are deduplicated by attachment ID. | TestRail 5.7+ |
+| `entities` | Walk `get_suites → get_cases → get_attachments_for_case` plus (when enabled by `--entity-type`) `get_runs → get_attachments_for_run`, `get_plans → get_attachments_for_plan` + per-entry `get_attachments_for_plan_entry`, and `get_runs → get_tests → get_attachments_for_test` (the only path to result-bound attachments on Server &lt; 7.5). Results are deduplicated by attachment ID. | TestRail 5.7+ |
 | `auto` (default) | Probe the project endpoint once on the first project; fall back to `entities` only when the canonical `404 Unknown method` is returned. Any other error aborts the run — no silent fallback. | both |
 
 When the auto-probe falls back, an `INFO:` line is printed to stderr explaining the switch. In CI/non-interactive flows you can pin the strategy explicitly with `--scan-strategy=entities` or `--scan-strategy=project` to skip the probe call entirely.

--- a/docs/en/guides/interactive-mode.md
+++ b/docs/en/guides/interactive-mode.md
@@ -215,7 +215,9 @@ line are never overwritten by the wizard.
 gotr attachments cleanup
 # → Scope: All projects / Specific projects
 #   (specific) → Project IDs (comma-separated):
-# → Entity types (comma-separated, default: result):
+# → Parent kinds preset:
+#     all (case,run,plan,plan_entry,result,test)  ← default, prints ⚠️ warning
+#     case · run · plan,plan_entry · result,test · custom (comma-separated)
 # → Older than (e.g. 90d, 3M, 1y):
 # → Concurrency:
 # → 📦 Create snapshot before deletion? (recommended) [Y/n]

--- a/docs/ru/guides/commands/attachments.md
+++ b/docs/ru/guides/commands/attachments.md
@@ -154,7 +154,7 @@ gotr attachments cleanup --project 7,9 --older-than 30d --concurrency 8 --no-sna
 | --- | --- |
 | `--project <ids>` / `--all-projects` | Обязательный селектор охвата (взаимоисключающие). |
 | `--older-than <dur>` | Граница возраста (`7d`, `3M`, `1y`, `720h`). Обязателен, если не задан `--dry-run`. |
-| `--entity-type` | Фильтр по родителю: `case`, `run`, `plan`, `plan_entry`, `result`, `test` (по умолчанию `result`). |
+| `--entity-type` | Фильтр по родителю: `case`, `run`, `plan`, `plan_entry`, `result`, `test`. **Дефолт с v3.5.2: все шесть типов.** Если итоговый scope покрывает ВСЕ типы, перед сканированием в stderr печатается ⚠️ предупреждение; для суженного scope — однострочное `ℹ️`. Чтобы сузить обход, передайте явный список (например, `--entity-type result`). |
 | `--dry-run` | Только предпросмотр, без снапшота и удалений. |
 | `--no-snapshot` | Отключить страховочный снапшот. |
 | `--snapshot-retention <dur>` | Переопределить TTL снапшота (по умолчанию `7d`; учитывается в `gotr snap gc`). |
@@ -172,7 +172,7 @@ gotr attachments cleanup --project 7,9 --older-than 30d --concurrency 8 --no-sna
 | Стратегия | Как перечисляются вложения | Работает на |
 | --- | --- | --- |
 | `project` | Один bulk-вызов `get_attachments_for_project`. | TestRail 7.5+ / Cloud |
-| `entities` | Обход `get_suites → get_cases → get_attachments_for_case` (плюс опционально `get_runs` / `get_plans` в зависимости от `--entity-type`). Результаты дедуплицируются по ID вложения. | TestRail 5.7+ |
+| `entities` | Обход `get_suites → get_cases → get_attachments_for_case`; плюс (если разрешено `--entity-type`) `get_runs → get_attachments_for_run`, `get_plans → get_attachments_for_plan` + по entry `get_attachments_for_plan_entry`, и `get_runs → get_tests → get_attachments_for_test` (единственный путь к result-bound вложениям на Server &lt; 7.5). Результаты дедуплицируются по ID вложения. | TestRail 5.7+ |
 | `auto` (по умолчанию) | Один пробный вызов project-эндпоинта на первом проекте; переключение на `entities` происходит **только** при канонической ошибке `404 Unknown method`. Любая другая ошибка прерывает запуск — без молчаливого fallback. | оба варианта |
 
 При срабатывании fallback в stderr выводится строка `INFO:` с причиной переключения. В CI и неинтерактивных сценариях стратегию можно зафиксировать явно: `--scan-strategy=entities` или `--scan-strategy=project` — это полностью отключает probe-вызов.

--- a/docs/ru/guides/interactive-mode.md
+++ b/docs/ru/guides/interactive-mode.md
@@ -215,7 +215,9 @@ gotr sync suites
 gotr attachments cleanup
 # → Область: Все проекты / Конкретные проекты
 #   (конкретные) → ID проектов (через запятую):
-# → Типы сущностей (через запятую, по умолчанию: result):
+# → Пресет типов сущностей:
+#     all (case,run,plan,plan_entry,result,test)  ← по умолчанию, печатает ⚠️
+#     case · run · plan,plan_entry · result,test · custom (через запятую)
 # → Старше (например, 90d, 3M, 1y):
 # → Concurrency:
 # → 📦 Создать снапшот перед удалением? (рекомендуется) [Y/n]


### PR DESCRIPTION
Documentation shadow-sync for v3.5.2 (PR #70 already merged). Updates default --entity-type to ALL, documents scope notice, and adds per-entry plan walk + tests walk to entities strategy. No code changes.