### PR TITLE
docs: post-release v3.6.0 polish (badges, version, ghost & resume-aware backup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-05-07
+
+### Added — `attachments cleanup`: resume-aware backup and ghost tolerance
+
+- **Resume-aware backup.** When a cleanup is restarted via
+  `--resume <RUN_ID>`, the backup phase now reads the existing
+  `mapping.json`/`attachments.json` of the in-progress snapshot and
+  skips attachments that were already downloaded and hashed in the
+  previous attempt. Only the remaining IDs are fetched, hashed and
+  appended; partial snapshots are no longer re-downloaded from scratch.
+- **Ghost-attachment tolerance.** TestRail occasionally reports an
+  attachment ID in listings that immediately returns
+  `400 "attachment does not exist"` (or `404`) when fetched — a race
+  between listing and a concurrent deletion. Such IDs are now classified
+  as **ghosts** via `client.IsAttachmentNotFound`, skipped with a
+  `WARN: ghost attachment <id> skipped` line, and recorded in the new
+  `BackupResult.GhostIDs` slice so the rest of the run is not aborted.
+- **`Skipped` / `Ghost` counters in summaries.** The Markdown and PDF
+  cleanup reports gained a `Backed up (skipped, ghosts)` row in the
+  Summary block, and `ExecuteResult` exposes `BackupSkipped` and
+  `GhostIDs` for downstream tooling.
+- **Resume hint on interrupted Execute.** When `attachments cleanup`
+  fails after a `RUN_ID` has been issued, the CLI now prints
+  `⚠️ Cleanup interrupted. To resume from where it left off, run: gotr attachments cleanup --resume <run-id>`
+  before exiting non-zero.
+
 ### Added — `attachments cleanup`: snapshot completeness (v2 layout)
 
 - **SHA-256 integrity per attachment.** Every downloaded binary is

--- a/CHANGELOG.ru.md
+++ b/CHANGELOG.ru.md
@@ -11,6 +11,33 @@
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-05-07
+
+### Added — `attachments cleanup`: resume-aware бэкап и устойчивость к ghost-вложениям
+
+- **Resume-aware бэкап.** При перезапуске cleanup через `--resume <RUN_ID>`
+  фаза бэкапа теперь читает существующие `mapping.json`/`attachments.json`
+  незавершённого снапшота и пропускает вложения, уже скачанные и
+  хэшированные на прошлой попытке. Скачиваются, хэшируются и
+  дописываются только оставшиеся ID; частичные снапшоты больше не
+  перезаливаются с нуля.
+- **Устойчивость к ghost-вложениям.** TestRail иногда возвращает в
+  листинге ID вложения, которое сразу же отдаёт `400 "attachment does
+  not exist"` (или `404`) при загрузке — гонка между листингом и
+  параллельным удалением. Такие ID теперь классифицируются как
+  **ghost** через `client.IsAttachmentNotFound`, пропускаются с
+  предупреждением `WARN: ghost attachment <id> skipped` и фиксируются
+  в новом поле `BackupResult.GhostIDs`, не прерывая весь запуск.
+- **Счётчики `Skipped` / `Ghost` в сводках.** Отчёты cleanup в
+  Markdown и PDF получили строку `Backed up (skipped, ghosts)` в
+  блоке Summary, а `ExecuteResult` экспортирует `BackupSkipped` и
+  `GhostIDs` для интеграций.
+- **Подсказка resume при прерванном Execute.** При падении
+  `attachments cleanup` после того, как `RUN_ID` уже выдан, CLI
+  печатает
+  `⚠️ Cleanup interrupted. To resume from where it left off, run: gotr attachments cleanup --resume <run-id>`
+  и выходит с ненулевым кодом.
+
 ### Added — `attachments cleanup`: полнота снапшотов (формат v2)
 
 - **SHA-256 для каждого вложения.** Хэш считается потоком при загрузке

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.5.2-blue.svg" alt="Latest Release"/></a>
+  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.6.0-blue.svg" alt="Latest Release"/></a>
   <a href="go.mod"><img src="https://img.shields.io/badge/go-1.25-00ADD8.svg?logo=go" alt="Go"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/></a>
   <a href="docs/index.md"><img src="https://img.shields.io/badge/docs-EN%20%7C%20RU-purple.svg" alt="Docs"/></a>

--- a/README_ru.md
+++ b/README_ru.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.5.2-blue.svg" alt="Latest Release"/></a>
+  <a href="https://github.com/Korrnals/gotr/releases/latest"><img src="https://img.shields.io/badge/release-v3.6.0-blue.svg" alt="Latest Release"/></a>
   <a href="go.mod"><img src="https://img.shields.io/badge/go-1.25-00ADD8.svg?logo=go" alt="Go"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"/></a>
   <a href="docs/index.md"><img src="https://img.shields.io/badge/docs-EN%20%7C%20RU-purple.svg" alt="Docs"/></a>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,9 @@ import (
 
 var (
 	// Version is populated at build time via -ldflags.
-	Version = "3.5.2" // default value for local development
-	Commit  = "unknown"
-	Date    = "unknown"
+	Version = "3.6.0" // default value for local development
+	Commit  = "389c59e"
+	Date    = "2026-05-07"
 	userHomeDir = os.UserHomeDir
 	// processExit is the exit function; overridable in tests.
 	processExit = os.Exit

--- a/docs/en/guides/commands/attachments.md
+++ b/docs/en/guides/commands/attachments.md
@@ -274,6 +274,12 @@ Long entity-walk scans across many projects can fail mid-flight (network blip, C
 
 > The `--resume` invocation must match the original filter set. If the cached `FilterSnapshot` no longer matches what the CLI would build, the run aborts with `checkpoint mismatch` rather than silently mixing two filters.
 
+**🧱 Resume-aware backup & ghost tolerance (since v3.6.0):**
+
+- **Resume-aware backup.** When `--resume <RUN_ID>` reuses a partially-finished snapshot, the backup phase reads the existing `mapping.json`/`attachments.json` and **skips attachments that were already downloaded and hashed** in the previous attempt. Only the remaining IDs are fetched. The Markdown / PDF Summary block reports the count under `Backed up (skipped, ghosts)`.
+- **Ghost attachments.** TestRail occasionally lists an attachment id that immediately returns `400 "attachment does not exist"` (or `404`) when the binary is fetched — a race between listing and a concurrent deletion. Such IDs are detected via `IsAttachmentNotFound`, logged as `WARN: ghost attachment <id> skipped`, recorded in `BackupResult.GhostIDs` / `ExecuteResult.GhostIDs`, and **do not abort the run**. The same Summary row aggregates them.
+- **Interrupted Execute hint.** When `attachments cleanup` fails after a `RUN_ID` has been issued, the CLI prints `⚠️  Cleanup interrupted. To resume from where it left off, run: gotr attachments cleanup --resume <run-id>` before exiting non-zero, so resuming is always one copy-paste away.
+
 **📊 Progress reporting (since v3.6.1):**
 
 The scan phase emits a 5-line live block on stderr when stderr is a TTY (and `--quiet` is not set):

--- a/docs/ru/guides/commands/attachments.md
+++ b/docs/ru/guides/commands/attachments.md
@@ -274,6 +274,12 @@ Dry-run отчёты содержат маркер `DRY-RUN` в шапке Markd
 
 > Запуск `--resume` обязан совпадать с исходным фильтром. Если сохранённый `FilterSnapshot` не совпадает с тем, что построил CLI, запуск аварийно завершается с ошибкой `checkpoint mismatch`, а не молча смешивает два фильтра.
 
+**🧱 Resume-aware бэкап и устойчивость к ghost-вложениям (с v3.6.0):**
+
+- **Resume-aware бэкап.** Когда `--resume <RUN_ID>` переиспользует частично завершённый снапшот, фаза бэкапа читает существующие `mapping.json`/`attachments.json` и **пропускает вложения, которые уже были скачаны и хешированы** на прошлой попытке. Скачиваются только оставшиеся ID. Markdown- и PDF-блок Summary показывает количество в строке `Backed up (skipped, ghosts)`.
+- **Ghost-вложения.** TestRail иногда отдаёт в листинге ID, который тут же возвращает `400 "attachment does not exist"` (или `404`) при загрузке бинарника — гонка между листингом и параллельным удалением. Такие ID детектируются через `IsAttachmentNotFound`, логируются как `WARN: ghost attachment <id> skipped`, фиксируются в `BackupResult.GhostIDs` / `ExecuteResult.GhostIDs` и **не прерывают запуск**. Та же строка Summary их агрегирует.
+- **Подсказка resume при прерывании.** При падении `attachments cleanup` после выдачи `RUN_ID` CLI печатает `⚠️  Cleanup interrupted. To resume from where it left off, run: gotr attachments cleanup --resume <run-id>` перед ненулевым exit-кодом — возобновление всегда в одном copy-paste.
+
 **📊 Отчётность о прогрессе (начиная с v3.6.1):**
 
 На фазе сканирования в stderr выводится 5-строчный «живой» блок (если stderr — TTY и не указан `--quiet`):


### PR DESCRIPTION
## Summary

Post-release polish for v3.6.0 — items that didn't make it into the release PR #78.

## Changes

### Version metadata (`cmd/root.go`)
- `Version` bumped `3.5.2` → `3.6.0`
- `Commit` default updated `unknown` → `389c59e` (release commit on `main`)
- `Date` default updated `unknown` → `2026-05-07`

> ldflags still override these at build time via the Makefile; only the local-development defaults change.

### README badges
- `README.md` and `README_ru.md`: `release-v3.5.2-blue` → `release-v3.6.0-blue`

### CHANGELOG
- Promoted `[Unreleased]` → `[3.6.0] - 2026-05-07` in both `CHANGELOG.md` and `CHANGELOG.ru.md`
- Added a new subsection covering the late v3.6.0 fixes that are not yet in the changelog:
  - Resume-aware backup (skips already-downloaded attachments on `--resume`)
  - Ghost-attachment tolerance (`IsAttachmentNotFound`, `BackupResult.GhostIDs`)
  - `Skipped` / `Ghost` counters in Markdown + PDF Summary
  - `--resume` hint on interrupted Execute

### Docs (`docs/{en,ru}/guides/commands/attachments.md`)
- New "Resume-aware backup & ghost tolerance" callout right after the "Recovery & resume" block

## Validation

- `go build ./...` ✅
- `go test ./cmd/ -run Version -v` ✅ (`TestVersion_Properties` PASS)

No code changes outside the version constants — purely docs + version-string update.